### PR TITLE
Merge upstream 4.1.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.1.0
+current_version = 4.1.1
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?P<releaselevel>[a-z]+)?

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 
 |build-status| |license| |wheel| |pyversion| |pyimp|
 
-:Version: 4.1.0 (latentcall)
+:Version: 4.1.1 (latentcall)
 :Web: http://celeryproject.org/
 :Download: https://pypi.python.org/pypi/celery/
 :Source: https://github.com/celery/celery/

--- a/celery/__init__.py
+++ b/celery/__init__.py
@@ -14,7 +14,7 @@ from collections import namedtuple
 
 SERIES = 'latentcall'
 
-__version__ = '4.1.0'
+__version__ = '4.1.1'
 __author__ = 'Ask Solem'
 __contact__ = 'ask@celeryproject.org'
 __homepage__ = 'http://celeryproject.org'
@@ -144,6 +144,7 @@ def maybe_patch_concurrency(argv=sys.argv,
         # set up eventlet/gevent environments ASAP
         from celery import concurrency
         concurrency.get_implementation(pool)
+
 
 # Lazy loading
 from . import local  # noqa

--- a/celery/__main__.py
+++ b/celery/__main__.py
@@ -1,6 +1,8 @@
 """Entry-point for the :program:`celery` umbrella command."""
 from __future__ import absolute_import, print_function, unicode_literals
+
 import sys
+
 from . import maybe_patch_concurrency
 
 __all__ = ['main']

--- a/celery/_state.py
+++ b/celery/_state.py
@@ -7,10 +7,12 @@ like the ``current_app``, and ``current_task``.
 This module shouldn't be used directly.
 """
 from __future__ import absolute_import, print_function, unicode_literals
+
 import os
 import sys
 import threading
 import weakref
+
 from celery.local import Proxy
 from celery.utils.threads import LocalStack
 

--- a/celery/app/amqp.py
+++ b/celery/app/amqp.py
@@ -4,13 +4,11 @@ from __future__ import absolute_import, unicode_literals
 
 import numbers
 import sys
-
 from collections import Mapping, namedtuple
 from datetime import timedelta
 from weakref import WeakValueDictionary
 
-from kombu import pools
-from kombu import Connection, Consumer, Exchange, Producer, Queue
+from kombu import Connection, Consumer, Exchange, Producer, Queue, pools
 from kombu.common import Broadcast
 from kombu.utils.functional import maybe_list
 from kombu.utils.objects import cached_property
@@ -523,7 +521,7 @@ class AMQP(object):
 
             # convert to anon-exchange, when exchange not set and direct ex.
             if (not exchange or not routing_key) and exchange_type == 'direct':
-                    exchange, routing_key = '', qname
+                exchange, routing_key = '', qname
             elif exchange is None:
                 # not topic exchange, and exchange not undefined
                 exchange = queue.exchange.name or default_exchange

--- a/celery/app/annotations.py
+++ b/celery/app/annotations.py
@@ -8,6 +8,7 @@ This prepares and performs the annotations in the
 :setting:`task_annotations` setting.
 """
 from __future__ import absolute_import, unicode_literals
+
 from celery.five import string_t
 from celery.utils.functional import firstmethod, mlazy
 from celery.utils.imports import instantiate

--- a/celery/app/backends.py
+++ b/celery/app/backends.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 """Backend selection."""
 from __future__ import absolute_import, unicode_literals
+
 import sys
 import types
-from celery.exceptions import ImproperlyConfigured
+
 from celery._state import current_app
+from celery.exceptions import ImproperlyConfigured
 from celery.five import reraise
 from celery.utils.imports import load_extension_class_names, symbol_by_name
 

--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import, unicode_literals
 import os
 import threading
 import warnings
-
 from collections import defaultdict, deque
 from operator import attrgetter
 
@@ -18,42 +17,34 @@ from kombu.utils.uuid import uuid
 from vine import starpromise
 from vine.utils import wraps
 
-from celery import platforms
-from celery import signals
-from celery._state import (
-    _task_stack, get_current_app, _set_current_app, set_default_app,
-    _register_app, _deregister_app,
-    get_current_worker_task, connect_on_app_finalize,
-    _announce_app_finalized,
-)
+from celery import platforms, signals
+from celery._state import (_announce_app_finalized, _deregister_app,
+                           _register_app, _set_current_app, _task_stack,
+                           connect_on_app_finalize, get_current_app,
+                           get_current_worker_task, set_default_app)
 from celery.exceptions import AlwaysEagerIgnored, ImproperlyConfigured
-from celery.five import (
-    UserDict, bytes_if_py2, python_2_unicode_compatible, values,
-)
+from celery.five import (UserDict, bytes_if_py2, python_2_unicode_compatible,
+                         values)
 from celery.loaders import get_loader_cls
 from celery.local import PromiseProxy, maybe_evaluate
 from celery.utils import abstract
 from celery.utils.collections import AttributeDictMixin
 from celery.utils.dispatch import Signal
-from celery.utils.functional import first, maybe_list, head_from_fun
-from celery.utils.time import timezone
+from celery.utils.functional import first, head_from_fun, maybe_list
 from celery.utils.imports import gen_task_name, instantiate, symbol_by_name
 from celery.utils.log import get_logger
 from celery.utils.objects import FallbackContext, mro_lookup
-
-from .annotations import prepare as prepare_annotations
-from . import backends
-from .defaults import find_deprecated_settings
-from .registry import TaskRegistry
-from .utils import (
-    AppPickler, Settings,
-    bugreport, _unpickle_app, _unpickle_app_v2,
-    _old_key_to_new, _new_key_to_old,
-    appstr, detect_settings,
-)
+from celery.utils.time import timezone
 
 # Load all builtin tasks
 from . import builtins  # noqa
+from . import backends
+from .annotations import prepare as prepare_annotations
+from .defaults import find_deprecated_settings
+from .registry import TaskRegistry
+from .utils import (AppPickler, Settings, _new_key_to_old, _old_key_to_new,
+                    _unpickle_app, _unpickle_app_v2, appstr, bugreport,
+                    detect_settings)
 
 __all__ = ['Celery']
 
@@ -1254,4 +1245,6 @@ class Celery(object):
                 if not conf.timezone:
                     return timezone.local
         return timezone.get_timezone(tz)
+
+
 App = Celery  # noqa: E305 XXX compat

--- a/celery/app/builtins.py
+++ b/celery/app/builtins.py
@@ -4,6 +4,7 @@
 The built-in tasks are always available in all app instances.
 """
 from __future__ import absolute_import, unicode_literals
+
 from celery._state import connect_on_app_finalize
 from celery.utils.log import get_logger
 

--- a/celery/app/control.py
+++ b/celery/app/control.py
@@ -5,11 +5,14 @@ Client for worker remote control commands.
 Server implementation is in :mod:`celery.worker.control`.
 """
 from __future__ import absolute_import, unicode_literals
+
 import warnings
+
 from billiard.common import TERM_SIGNAME
 from kombu.pidbox import Mailbox
 from kombu.utils.functional import lazy
 from kombu.utils.objects import cached_property
+
 from celery.exceptions import DuplicateNodenameWarning
 from celery.utils.text import pluralize
 

--- a/celery/app/defaults.py
+++ b/celery/app/defaults.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 """Configuration introspection and defaults."""
 from __future__ import absolute_import, unicode_literals
+
 import sys
 from collections import deque, namedtuple
 from datetime import timedelta
+
 from celery.five import items, keys, python_2_unicode_compatible
 from celery.utils.functional import memoize
 from celery.utils.serialization import strtobool

--- a/celery/app/events.py
+++ b/celery/app/events.py
@@ -1,6 +1,8 @@
 """Implementation for the app.events shortcuts."""
 from __future__ import absolute_import, unicode_literals
+
 from contextlib import contextmanager
+
 from kombu.utils.objects import cached_property
 
 

--- a/celery/app/log.py
+++ b/celery/app/log.py
@@ -12,7 +12,6 @@ from __future__ import absolute_import, unicode_literals
 import logging
 import os
 import sys
-
 from logging.handlers import WatchedFileHandler
 
 from kombu.utils.encoding import set_default_encoding_file
@@ -22,11 +21,9 @@ from celery._state import get_current_task
 from celery.five import string_t
 from celery.local import class_property
 from celery.platforms import isatty
-from celery.utils.log import (
-    get_logger, mlevel,
-    ColorFormatter, LoggingProxy, get_multiprocessing_logger,
-    reset_multiprocessing_logger,
-)
+from celery.utils.log import (ColorFormatter, LoggingProxy, get_logger,
+                              get_multiprocessing_logger, mlevel,
+                              reset_multiprocessing_logger)
 from celery.utils.nodenames import node_format
 from celery.utils.term import colored
 

--- a/celery/app/registry.py
+++ b/celery/app/registry.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 """Registry of available tasks."""
 from __future__ import absolute_import, unicode_literals
+
 import inspect
 from importlib import import_module
+
 from celery._state import get_current_app
-from celery.exceptions import NotRegistered, InvalidTaskError
+from celery.exceptions import InvalidTaskError, NotRegistered
 from celery.five import items
 
 __all__ = ['TaskRegistry']

--- a/celery/app/routes.py
+++ b/celery/app/routes.py
@@ -4,10 +4,13 @@
 Contains utilities for working with task routers, (:setting:`task_routes`).
 """
 from __future__ import absolute_import, unicode_literals
+
 import re
 import string
 from collections import Mapping, OrderedDict
+
 from kombu import Queue
+
 from celery.exceptions import QueueNotFound
 from celery.five import items, string_t
 from celery.utils.collections import lpmerge

--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -8,8 +8,7 @@ from billiard.einfo import ExceptionInfo
 from kombu.exceptions import OperationalError
 from kombu.utils.uuid import uuid
 
-from celery import current_app, group
-from celery import states
+from celery import current_app, group, states
 from celery._state import _task_stack
 from celery.canvas import signature
 from celery.exceptions import Ignore, MaxRetriesExceededError, Reject, Retry
@@ -1006,4 +1005,6 @@ class Task(object):
     @property
     def __name__(self):
         return self.__class__.__name__
+
+
 BaseTask = Task  # noqa: E305 XXX compat alias

--- a/celery/app/trace.py
+++ b/celery/app/trace.py
@@ -6,6 +6,32 @@ errors are recorded, handlers are applied and so on.
 """
 from __future__ import absolute_import, unicode_literals
 
+import logging
+import os
+import sys
+from collections import namedtuple
+from warnings import warn
+
+from billiard.einfo import ExceptionInfo
+from kombu.exceptions import EncodeError
+from kombu.serialization import loads as loads_message
+from kombu.serialization import prepare_accept_content
+from kombu.utils.encoding import safe_repr, safe_str
+
+from celery import current_app, group, signals, states
+from celery._state import _task_stack
+from celery.app.task import Context
+from celery.app.task import Task as BaseTask
+from celery.exceptions import Ignore, InvalidTaskError, Reject, Retry
+from celery.five import monotonic, text_t
+from celery.utils.log import get_logger
+from celery.utils.nodenames import gethostname
+from celery.utils.objects import mro_lookup
+from celery.utils.saferepr import saferepr
+from celery.utils.serialization import (get_pickleable_etype,
+                                        get_pickleable_exception,
+                                        get_pickled_exception)
+
 # ## ---
 # This is the heart of the worker, the inner loop so to speak.
 # It used to be split up into nice little classes and methods,
@@ -17,31 +43,6 @@ from __future__ import absolute_import, unicode_literals
 # pylint: disable=broad-except
 # We know what we're doing...
 
-import logging
-import os
-import sys
-
-from collections import namedtuple
-from warnings import warn
-
-from billiard.einfo import ExceptionInfo
-from kombu.exceptions import EncodeError
-from kombu.serialization import loads as loads_message, prepare_accept_content
-from kombu.utils.encoding import safe_repr, safe_str
-
-from celery import current_app, group
-from celery import states, signals
-from celery._state import _task_stack
-from celery.app.task import Task as BaseTask, Context
-from celery.exceptions import Ignore, Reject, Retry, InvalidTaskError
-from celery.five import monotonic, text_t
-from celery.utils.log import get_logger
-from celery.utils.nodenames import gethostname
-from celery.utils.objects import mro_lookup
-from celery.utils.saferepr import saferepr
-from celery.utils.serialization import (
-    get_pickleable_exception, get_pickled_exception, get_pickleable_etype,
-)
 
 __all__ = [
     'TraceInfo', 'build_tracer', 'trace_task',
@@ -515,6 +516,8 @@ def _trace_task_ret(name, uuid, request, body, content_type,
     R, I, T, Rstr = trace_task(app.tasks[name],
                                uuid, args, kwargs, request, app=app)
     return (1, R, T) if I else (0, Rstr, T)
+
+
 trace_task_ret = _trace_task_ret  # noqa: E305
 
 

--- a/celery/app/utils.py
+++ b/celery/app/utils.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import, unicode_literals
 import os
 import platform as _platform
 import re
-
 from collections import Mapping, namedtuple
 from copy import deepcopy
 from types import ModuleType
@@ -16,13 +15,11 @@ from celery.exceptions import ImproperlyConfigured
 from celery.five import items, keys, string_t, values
 from celery.platforms import pyimplementation
 from celery.utils.collections import ConfigurationView
+from celery.utils.imports import import_from_cwd, qualname, symbol_by_name
 from celery.utils.text import pretty
-from celery.utils.imports import import_from_cwd, symbol_by_name, qualname
 
-from .defaults import (
-    _TO_NEW_KEY, _TO_OLD_KEY, _OLD_DEFAULTS, _OLD_SETTING_KEYS,
-    DEFAULTS, SETTING_KEYS, find,
-)
+from .defaults import (_OLD_DEFAULTS, _OLD_SETTING_KEYS, _TO_NEW_KEY,
+                       _TO_OLD_KEY, DEFAULTS, SETTING_KEYS, find)
 
 __all__ = [
     'Settings', 'appstr', 'bugreport',

--- a/celery/apps/beat.py
+++ b/celery/apps/beat.py
@@ -8,11 +8,13 @@ as an actual application, like installing signal handlers
 and so on.
 """
 from __future__ import absolute_import, print_function, unicode_literals
+
 import numbers
 import socket
 import sys
 from datetime import datetime
-from celery import VERSION_BANNER, platforms, beat
+
+from celery import VERSION_BANNER, beat, platforms
 from celery.five import text_t
 from celery.utils.imports import qualname
 from celery.utils.log import LOG_LEVELS, get_logger
@@ -115,9 +117,9 @@ class Beat(object):
         c = self.colored
         return text_t(  # flake8: noqa
             c.blue('__    ', c.magenta('-'),
-            c.blue('    ... __   '), c.magenta('-'),
-            c.blue('        _\n'),
-            c.reset(self.startup_info(service))),
+                   c.blue('    ... __   '), c.magenta('-'),
+                   c.blue('        _\n'),
+                   c.reset(self.startup_info(service))),
         )
 
     def init_loader(self):

--- a/celery/apps/multi.py
+++ b/celery/apps/multi.py
@@ -6,7 +6,6 @@ import os
 import shlex
 import signal
 import sys
-
 from collections import OrderedDict, defaultdict
 from functools import partial
 from subprocess import Popen
@@ -17,9 +16,8 @@ from kombu.utils.objects import cached_property
 
 from celery.five import UserList, items
 from celery.platforms import IS_WINDOWS, Pidfile, signal_name
-from celery.utils.nodenames import (
-    gethostname, host_format, node_format, nodesplit,
-)
+from celery.utils.nodenames import (gethostname, host_format, node_format,
+                                    nodesplit)
 from celery.utils.saferepr import saferepr
 
 __all__ = ['Cluster', 'Node']

--- a/celery/apps/worker.py
+++ b/celery/apps/worker.py
@@ -13,23 +13,19 @@ import logging
 import os
 import platform as _platform
 import sys
-
 from datetime import datetime
 from functools import partial
 
 from billiard.process import current_process
 from kombu.utils.encoding import safe_str
 
-from celery import VERSION_BANNER
-from celery import platforms
-from celery import signals
+from celery import VERSION_BANNER, platforms, signals
 from celery.app import trace
 from celery.exceptions import WorkerShutdown, WorkerTerminate
 from celery.five import string, string_t
 from celery.loaders.app import AppLoader
 from celery.platforms import EX_FAILURE, EX_OK, check_privileges, isatty
-from celery.utils import static
-from celery.utils import term
+from celery.utils import static, term
 from celery.utils.debug import cry
 from celery.utils.imports import qualname
 from celery.utils.log import get_logger, in_sighandler, set_in_sighandler

--- a/celery/backends/amqp.py
+++ b/celery/backends/amqp.py
@@ -3,15 +3,14 @@
 from __future__ import absolute_import, unicode_literals
 
 import socket
-
 from collections import deque
 from operator import itemgetter
 
-from kombu import Exchange, Queue, Producer, Consumer
+from kombu import Consumer, Exchange, Producer, Queue
 
 from celery import states
 from celery.exceptions import TimeoutError
-from celery.five import range, monotonic
+from celery.five import monotonic, range
 from celery.utils import deprecated
 from celery.utils.log import get_logger
 

--- a/celery/backends/async.py
+++ b/celery/backends/async.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, unicode_literals
 
 import socket
 import threading
-
 from collections import deque
 from time import sleep
 from weakref import WeakKeyDictionary

--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -10,37 +10,29 @@ from __future__ import absolute_import, unicode_literals
 
 import sys
 import time
-
 from collections import namedtuple
 from datetime import timedelta
 from weakref import WeakValueDictionary
 
 from billiard.einfo import ExceptionInfo
-from kombu.serialization import (
-    dumps, loads, prepare_accept_content,
-    registry as serializer_registry,
-)
+from kombu.serialization import dumps, loads, prepare_accept_content
+from kombu.serialization import registry as serializer_registry
 from kombu.utils.encoding import bytes_to_str, ensure_bytes, from_utf8
 from kombu.utils.url import maybe_sanitize_url
 
-from celery import states
-from celery import current_app, group, maybe_signature
+from celery import current_app, group, maybe_signature, states
 from celery._state import get_current_task
-from celery.exceptions import (
-    ChordError, TimeoutError, TaskRevokedError, ImproperlyConfigured,
-)
+from celery.exceptions import (ChordError, ImproperlyConfigured,
+                               TaskRevokedError, TimeoutError)
 from celery.five import items, string
-from celery.result import (
-    GroupResult, ResultBase, allow_join_result, result_from_tuple,
-)
+from celery.result import (GroupResult, ResultBase, allow_join_result,
+                           result_from_tuple)
 from celery.utils.collections import BufferMap
 from celery.utils.functional import LRUCache, arity_greater
 from celery.utils.log import get_logger
-from celery.utils.serialization import (
-    get_pickled_exception,
-    get_pickleable_exception,
-    create_exception_cls,
-)
+from celery.utils.serialization import (create_exception_cls,
+                                        get_pickleable_exception,
+                                        get_pickled_exception)
 
 __all__ = ['BaseBackend', 'KeyValueStoreBackend', 'DisabledBackend']
 
@@ -510,6 +502,8 @@ class SyncBackendMixin(object):
 
 class BaseBackend(Backend, SyncBackendMixin):
     """Base (synchronous) result backend."""
+
+
 BaseDictBackend = BaseBackend  # noqa: E305 XXX compat
 
 

--- a/celery/backends/cache.py
+++ b/celery/backends/cache.py
@@ -1,11 +1,15 @@
 # -*- coding: utf-8 -*-
 """Memcached and in-memory cache result backend."""
 from __future__ import absolute_import, unicode_literals
+
 import sys
+
 from kombu.utils.encoding import bytes_to_str, ensure_bytes
 from kombu.utils.objects import cached_property
+
 from celery.exceptions import ImproperlyConfigured
 from celery.utils.functional import LRUCache
+
 from .base import KeyValueStoreBackend
 
 __all__ = ['CacheBackend']

--- a/celery/backends/cassandra.py
+++ b/celery/backends/cassandra.py
@@ -1,11 +1,15 @@
 # -* coding: utf-8 -*-
 """Apache Cassandra result store backend using the DataStax driver."""
 from __future__ import absolute_import, unicode_literals
+
 import sys
+
 from celery import states
 from celery.exceptions import ImproperlyConfigured
 from celery.utils.log import get_logger
+
 from .base import BaseBackend
+
 try:  # pragma: no cover
     import cassandra
     import cassandra.auth

--- a/celery/backends/consul.py
+++ b/celery/backends/consul.py
@@ -5,10 +5,13 @@
     in the key-value store of Consul.
 """
 from __future__ import absolute_import, unicode_literals
+
 from kombu.utils.url import parse_url
+
+from celery.backends.base import PY3, KeyValueStoreBackend
 from celery.exceptions import ImproperlyConfigured
-from celery.backends.base import KeyValueStoreBackend, PY3
 from celery.utils.log import get_logger
+
 try:
     import consul
 except ImportError:

--- a/celery/backends/couchbase.py
+++ b/celery/backends/couchbase.py
@@ -1,11 +1,16 @@
 # -*- coding: utf-8 -*-
 """Couchbase result store backend."""
 from __future__ import absolute_import, unicode_literals
+
 import logging
+
 from kombu.utils.encoding import str_t
 from kombu.utils.url import _parse_url
+
 from celery.exceptions import ImproperlyConfigured
+
 from .base import KeyValueStoreBackend
+
 try:
     from couchbase import Couchbase
     from couchbase.connection import Connection

--- a/celery/backends/couchdb.py
+++ b/celery/backends/couchdb.py
@@ -1,9 +1,13 @@
 # -*- coding: utf-8 -*-
 """CouchDB result store backend."""
 from __future__ import absolute_import, unicode_literals
+
 from kombu.utils.url import _parse_url
+
 from celery.exceptions import ImproperlyConfigured
+
 from .base import KeyValueStoreBackend
+
 try:
     import pycouchdb
 except ImportError:

--- a/celery/backends/database/models.py
+++ b/celery/backends/database/models.py
@@ -1,11 +1,15 @@
 # -*- coding: utf-8 -*-
 """Database models used by the SQLAlchemy result store backend."""
 from __future__ import absolute_import, unicode_literals
-import sqlalchemy as sa
+
 from datetime import datetime
+
+import sqlalchemy as sa
 from sqlalchemy.types import PickleType
+
 from celery import states
 from celery.five import python_2_unicode_compatible
+
 from .session import ResultModelBase
 
 __all__ = ['Task', 'TaskSet']

--- a/celery/backends/database/session.py
+++ b/celery/backends/database/session.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 """SQLAlchemy session."""
 from __future__ import absolute_import, unicode_literals
+
+from kombu.utils.compat import register_after_fork
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import NullPool
-from kombu.utils.compat import register_after_fork
 
 ResultModelBase = declarative_base()
 

--- a/celery/backends/dynamodb.py
+++ b/celery/backends/dynamodb.py
@@ -1,14 +1,18 @@
 # -*- coding: utf-8 -*-
 """AWS DynamoDB result store backend."""
 from __future__ import absolute_import, unicode_literals
+
 from collections import namedtuple
-from time import time, sleep
+from time import sleep, time
 
 from kombu.utils.url import _parse_url as parse_url
+
 from celery.exceptions import ImproperlyConfigured
-from celery.utils.log import get_logger
 from celery.five import string
+from celery.utils.log import get_logger
+
 from .base import KeyValueStoreBackend
+
 try:
     import boto3
     from botocore.exceptions import ClientError

--- a/celery/backends/elasticsearch.py
+++ b/celery/backends/elasticsearch.py
@@ -1,12 +1,17 @@
 # -* coding: utf-8 -*-
 """Elasticsearch result store backend."""
 from __future__ import absolute_import, unicode_literals
+
 from datetime import datetime
-from kombu.utils.url import _parse_url
+
 from kombu.utils.encoding import bytes_to_str
+from kombu.utils.url import _parse_url
+
 from celery.exceptions import ImproperlyConfigured
 from celery.five import items
+
 from .base import KeyValueStoreBackend
+
 try:
     import elasticsearch
 except ImportError:

--- a/celery/backends/filesystem.py
+++ b/celery/backends/filesystem.py
@@ -1,12 +1,15 @@
 # -*- coding: utf-8 -*-
 """File-system result store backend."""
 from __future__ import absolute_import, unicode_literals
-import os
+
 import locale
+import os
+
 from kombu.utils.encoding import ensure_bytes
+
 from celery import uuid
-from celery.exceptions import ImproperlyConfigured
 from celery.backends.base import KeyValueStoreBackend
+from celery.exceptions import ImproperlyConfigured
 
 # Python 2 does not have FileNotFoundError and IsADirectoryError
 try:

--- a/celery/backends/mongodb.py
+++ b/celery/backends/mongodb.py
@@ -1,13 +1,17 @@
 # -*- coding: utf-8 -*-
 """MongoDB result store backend."""
 from __future__ import absolute_import, unicode_literals
+
 from datetime import datetime, timedelta
+
+from kombu.exceptions import EncodeError
 from kombu.utils.objects import cached_property
 from kombu.utils.url import maybe_sanitize_url
-from kombu.exceptions import EncodeError
+
 from celery import states
 from celery.exceptions import ImproperlyConfigured
-from celery.five import string_t, items
+from celery.five import items, string_t
+
 from .base import BaseBackend
 
 try:
@@ -117,11 +121,11 @@ class MongoBackend(BaseBackend):
             self.options.update(config)
 
     def _prepare_client_options(self):
-            if pymongo.version_tuple >= (3,):
-                return {'maxPoolSize': self.max_pool_size}
-            else:  # pragma: no cover
-                return {'max_pool_size': self.max_pool_size,
-                        'auto_start_request': False}
+        if pymongo.version_tuple >= (3,):
+            return {'maxPoolSize': self.max_pool_size}
+        else:  # pragma: no cover
+            return {'max_pool_size': self.max_pool_size,
+                    'auto_start_request': False}
 
     def _get_connection(self):
         """Connect to the MongoDB server."""

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -18,8 +18,7 @@ from celery.utils.functional import dictfilter
 from celery.utils.log import get_logger
 from celery.utils.time import humanize_seconds
 
-from . import async
-from . import base
+from . import async, base
 
 try:
     import redis

--- a/celery/backends/riak.py
+++ b/celery/backends/riak.py
@@ -1,10 +1,15 @@
 # -*- coding: utf-8 -*-
 """Riak result store backend."""
 from __future__ import absolute_import, unicode_literals
+
 import sys
+
 from kombu.utils.url import _parse_url
+
 from celery.exceptions import ImproperlyConfigured
+
 from .base import KeyValueStoreBackend
+
 try:
     import riak
     from riak import RiakClient

--- a/celery/backends/rpc.py
+++ b/celery/backends/rpc.py
@@ -5,9 +5,9 @@ RPC-style result backend, using reply-to and one queue per client.
 """
 from __future__ import absolute_import, unicode_literals
 
-import kombu
 import time
 
+import kombu
 from kombu.common import maybe_declare
 from kombu.utils.compat import register_after_fork
 from kombu.utils.objects import cached_property

--- a/celery/beat.py
+++ b/celery/beat.py
@@ -6,31 +6,27 @@ import copy
 import errno
 import heapq
 import os
-import time
 import shelve
 import sys
+import time
 import traceback
-
 from collections import namedtuple
 from functools import total_ordering
 from threading import Event, Thread
 
 from billiard import ensure_multiprocessing
-from billiard.context import Process
 from billiard.common import reset_signals
+from billiard.context import Process
 from kombu.utils.functional import maybe_evaluate, reprcall
 from kombu.utils.objects import cached_property
 
-from . import __version__
-from . import platforms
-from . import signals
-from .five import (
-    items, monotonic, python_2_unicode_compatible, reraise, values,
-)
-from .schedules import maybe_schedule, crontab
+from . import __version__, platforms, signals
+from .five import (items, monotonic, python_2_unicode_compatible, reraise,
+                   values)
+from .schedules import crontab, maybe_schedule
 from .utils.imports import load_extension_class_names, symbol_by_name
-from .utils.time import humanize_seconds
 from .utils.log import get_logger, iter_open_logger_fds
+from .utils.time import humanize_seconds
 
 __all__ = [
     'SchedulingError', 'ScheduleEntry', 'Scheduler',

--- a/celery/bin/amqp.py
+++ b/celery/bin/amqp.py
@@ -6,19 +6,17 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 import cmd as _cmd
-import sys
-import shlex
 import pprint
-
+import shlex
+import sys
 from functools import partial
 from itertools import count
 
 from kombu.utils.encoding import safe_str
 
-from celery.utils.functional import padlist
-
 from celery.bin.base import Command
 from celery.five import string_t
+from celery.utils.functional import padlist
 from celery.utils.serialization import strtobool
 
 __all__ = ['AMQPAdmin', 'AMQShell', 'Spec', 'amqp']

--- a/celery/bin/base.py
+++ b/celery/bin/base.py
@@ -3,32 +3,26 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 import argparse
+import json
 import os
 import random
 import re
 import sys
 import warnings
-import json
-
 from collections import defaultdict
 from heapq import heappush
 from pprint import pformat
 
-from celery import VERSION_BANNER, Celery, maybe_patch_concurrency
-from celery import signals
+from celery import VERSION_BANNER, Celery, maybe_patch_concurrency, signals
 from celery.exceptions import CDeprecationWarning, CPendingDeprecationWarning
-from celery.five import (
-    getfullargspec, items, python_2_unicode_compatible,
-    string, string_t, text_t, long_t,
-)
+from celery.five import (getfullargspec, items, long_t,
+                         python_2_unicode_compatible, string, string_t,
+                         text_t)
 from celery.platforms import EX_FAILURE, EX_OK, EX_USAGE, isatty
-from celery.utils import imports
-from celery.utils import term
-from celery.utils import text
+from celery.utils import imports, term, text
 from celery.utils.functional import dictfilter
-from celery.utils.nodenames import node_format, host_format
+from celery.utils.nodenames import host_format, node_format
 from celery.utils.objects import Bunch
-
 
 # Option is here for backwards compatiblity, as third-party commands
 # may import it from here.
@@ -85,7 +79,7 @@ def _add_optparse_argument(parser, opt, typemap={
     # store_true sets value to "('NO', 'DEFAULT')" for some
     # crazy reason, so not to set a sane default here.
     if opt.action == 'store_true' and opt.default is None:
-            opt.default = False
+        opt.default = False
     parser.add_argument(
         *opt._long_opts + opt._short_opts,
         **dictfilter(dict(

--- a/celery/bin/beat.py
+++ b/celery/bin/beat.py
@@ -65,9 +65,11 @@
     Executable to use for the detached process.
 """
 from __future__ import absolute_import, unicode_literals
+
 from functools import partial
-from celery.platforms import detached, maybe_drop_privileges
+
 from celery.bin.base import Command, daemon_options
+from celery.platforms import detached, maybe_drop_privileges
 
 __all__ = ['beat']
 

--- a/celery/bin/call.py
+++ b/celery/bin/call.py
@@ -1,6 +1,8 @@
 """The ``celery call`` program used to send tasks from the command-line."""
 from __future__ import absolute_import, unicode_literals
+
 from kombu.utils.json import loads
+
 from celery.bin.base import Command
 from celery.five import string_t
 from celery.utils.time import maybe_iso8601

--- a/celery/bin/celery.py
+++ b/celery/bin/celery.py
@@ -253,22 +253,16 @@ in any command that also has a `--detach` option.
 
     Destination routing key (defaults to the queue routing key).
 """
-from __future__ import absolute_import, unicode_literals, print_function
+from __future__ import absolute_import, print_function, unicode_literals
 
 import numbers
 import sys
-
 from functools import partial
-
-from celery.platforms import EX_OK, EX_FAILURE, EX_USAGE
-from celery.utils import term
-from celery.utils import text
-
-# Cannot use relative imports here due to a Windows issue (#1111).
-from celery.bin.base import Command, Extensions
 
 # Import commands from other modules
 from celery.bin.amqp import amqp
+# Cannot use relative imports here due to a Windows issue (#1111).
+from celery.bin.base import Command, Extensions
 from celery.bin.beat import beat
 from celery.bin.call import call
 from celery.bin.control import _RemoteControl  # noqa
@@ -281,8 +275,10 @@ from celery.bin.migrate import migrate
 from celery.bin.purge import purge
 from celery.bin.result import result
 from celery.bin.shell import shell
-from celery.bin.worker import worker
 from celery.bin.upgrade import upgrade
+from celery.bin.worker import worker
+from celery.platforms import EX_FAILURE, EX_OK, EX_USAGE
+from celery.utils import term, text
 
 __all__ = ['CeleryCommand', 'main']
 

--- a/celery/bin/celeryd_detach.py
+++ b/celery/bin/celeryd_detach.py
@@ -6,14 +6,16 @@ leads to weird issues (it was a long time ago now, but it
 could have something to do with the threading mutex bug)
 """
 from __future__ import absolute_import, unicode_literals
+
 import argparse
-import celery
 import os
 import sys
+
+import celery
+from celery.bin.base import daemon_options
 from celery.platforms import EX_FAILURE, detached
 from celery.utils.log import get_logger
 from celery.utils.nodenames import default_nodename, node_format
-from celery.bin.base import daemon_options
 
 __all__ = ['detached_celeryd', 'detach']
 logger = get_logger(__name__)

--- a/celery/bin/control.py
+++ b/celery/bin/control.py
@@ -1,9 +1,11 @@
 """The ``celery control``, ``. inspect`` and ``. status`` programs."""
 from __future__ import absolute_import, unicode_literals
+
 from kombu.utils.json import dumps
 from kombu.utils.objects import cached_property
-from celery.five import items, string_t
+
 from celery.bin.base import Command
+from celery.five import items, string_t
 from celery.platforms import EX_UNAVAILABLE, EX_USAGE
 from celery.utils import text
 

--- a/celery/bin/events.py
+++ b/celery/bin/events.py
@@ -66,10 +66,12 @@
     Executable to use for the detached process.
 """
 from __future__ import absolute_import, unicode_literals
+
 import sys
 from functools import partial
-from celery.platforms import detached, set_process_title, strargv
+
 from celery.bin.base import Command, daemon_options
+from celery.platforms import detached, set_process_title, strargv
 
 __all__ = ['events']
 

--- a/celery/bin/graph.py
+++ b/celery/bin/graph.py
@@ -4,9 +4,12 @@
 .. program:: celery graph
 """
 from __future__ import absolute_import, unicode_literals
+
 from operator import itemgetter
+
 from celery.five import items, python_2_unicode_compatible
 from celery.utils.graph import DependencyGraph, GraphFormatter
+
 from .base import Command
 
 __all__ = ['graph']

--- a/celery/bin/list.py
+++ b/celery/bin/list.py
@@ -1,5 +1,6 @@
 """The ``celery list bindings`` command, used to inspect queue bindings."""
 from __future__ import absolute_import, unicode_literals
+
 from celery.bin.base import Command
 
 

--- a/celery/bin/logtool.py
+++ b/celery/bin/logtool.py
@@ -5,9 +5,11 @@
 """
 
 from __future__ import absolute_import, unicode_literals
+
 import re
 from collections import Counter
 from fileinput import FileInput
+
 from .base import Command
 
 __all__ = ['logtool']

--- a/celery/bin/migrate.py
+++ b/celery/bin/migrate.py
@@ -1,5 +1,6 @@
 """The ``celery migrate`` command, used to filter and move messages."""
 from __future__ import absolute_import, unicode_literals
+
 from celery.bin.base import Command
 
 MIGRATE_PROGRESS_FMT = """\

--- a/celery/bin/multi.py
+++ b/celery/bin/multi.py
@@ -94,11 +94,14 @@ Examples
     celery worker -n xuzzy@myhost -c 3
 """
 from __future__ import absolute_import, print_function, unicode_literals
+
 import os
 import signal
 import sys
 from functools import wraps
+
 from kombu.utils.objects import cached_property
+
 from celery import VERSION_BANNER
 from celery.apps.multi import Cluster, MultiParser, NamespacedOptionParser
 from celery.platforms import EX_FAILURE, EX_OK, signals

--- a/celery/bin/purge.py
+++ b/celery/bin/purge.py
@@ -1,7 +1,8 @@
 """The ``celery purge`` program, used to delete messages from queues."""
 from __future__ import absolute_import, unicode_literals
-from celery.five import keys
+
 from celery.bin.base import Command
+from celery.five import keys
 from celery.utils import text
 
 

--- a/celery/bin/result.py
+++ b/celery/bin/result.py
@@ -1,5 +1,6 @@
 """The ``celery result`` program, used to inspect task results."""
 from __future__ import absolute_import, unicode_literals
+
 from celery.bin.base import Command
 
 

--- a/celery/bin/shell.py
+++ b/celery/bin/shell.py
@@ -1,10 +1,12 @@
 """The ``celery shell`` program, used to start a REPL."""
 from __future__ import absolute_import, unicode_literals
+
 import os
 import sys
 from importlib import import_module
-from celery.five import values
+
 from celery.bin.base import Command
+from celery.five import values
 
 
 class shell(Command):  # pragma: no cover

--- a/celery/bin/upgrade.py
+++ b/celery/bin/upgrade.py
@@ -1,6 +1,8 @@
 """The ``celery upgrade`` command, used to upgrade from previous versions."""
 from __future__ import absolute_import, print_function, unicode_literals
+
 import codecs
+
 from celery.app import defaults
 from celery.bin.base import Command
 from celery.utils.functional import pass1

--- a/celery/bin/worker.py
+++ b/celery/bin/worker.py
@@ -176,7 +176,9 @@ The :program:`celery worker` command (previously known as ``celeryd``)
     Executable to use for the detached process.
 """
 from __future__ import absolute_import, unicode_literals
+
 import sys
+
 from celery import concurrency
 from celery.bin.base import Command, daemon_options
 from celery.bin.celeryd_detach import detached_celeryd

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -10,10 +10,10 @@ from __future__ import absolute_import, unicode_literals
 import itertools
 import operator
 import sys
-
 from collections import MutableSequence, deque
 from copy import deepcopy
-from functools import partial as _partial, reduce
+from functools import partial as _partial
+from functools import reduce
 from operator import itemgetter
 
 from kombu.utils.functional import fxrange, reprcall
@@ -26,12 +26,12 @@ from celery.five import python_2_unicode_compatible
 from celery.local import try_import
 from celery.result import GroupResult
 from celery.utils import abstract
-from celery.utils.functional import (
-    maybe_list, is_list, _regen, regen, chunks as _chunks,
-    seq_concat_seq, seq_concat_item,
-)
+from celery.utils.functional import _regen
+from celery.utils.functional import chunks as _chunks
+from celery.utils.functional import (is_list, maybe_list, regen,
+                                     seq_concat_item, seq_concat_seq)
 from celery.utils.objects import getitem_property
-from celery.utils.text import truncate, remove_repeating_from_task
+from celery.utils.text import remove_repeating_from_task, truncate
 
 __all__ = [
     'Signature', 'chain', 'xmap', 'xstarmap', 'chunks',
@@ -1364,6 +1364,8 @@ def signature(varies, *args, **kwargs):
             return varies.clone()
         return Signature.from_dict(varies, app=app)
     return Signature(varies, *args, **kwargs)
+
+
 subtask = signature  # noqa: E305 XXX compat
 
 
@@ -1392,4 +1394,6 @@ def maybe_signature(d, app=None, clone=False):
         if app is not None:
             d._app = app
     return d
+
+
 maybe_subtask = maybe_signature  # noqa: E305 XXX compat

--- a/celery/concurrency/asynpool.py
+++ b/celery/concurrency/asynpool.py
@@ -23,7 +23,6 @@ import socket
 import struct
 import sys
 import time
-
 from collections import deque, namedtuple
 from io import BytesIO
 from numbers import Integral
@@ -31,11 +30,11 @@ from pickle import HIGHEST_PROTOCOL
 from time import sleep
 from weakref import WeakValueDictionary, ref
 
-from billiard.pool import RUN, TERMINATE, ACK, NACK, WorkersJoined
 from billiard import pool as _pool
-from billiard.compat import buf_t, setblocking, isblocking
+from billiard.compat import buf_t, isblocking, setblocking
+from billiard.pool import ACK, NACK, RUN, TERMINATE, WorkersJoined
 from billiard.queues import _SimpleQueue
-from kombu.async import WRITE, ERR
+from kombu.asynchronous import ERR, WRITE
 from kombu.serialization import pickle as _pickle
 from kombu.utils.eventio import SELECT_BAD_FD
 from kombu.utils.functional import fxrange

--- a/celery/concurrency/base.py
+++ b/celery/concurrency/base.py
@@ -13,8 +13,8 @@ from kombu.utils.encoding import safe_repr
 from celery.exceptions import WorkerShutdown, WorkerTerminate
 from celery.five import monotonic, reraise
 from celery.utils import timer2
-from celery.utils.text import truncate
 from celery.utils.log import get_logger
+from celery.utils.text import truncate
 
 __all__ = ['BasePool', 'apply_target']
 

--- a/celery/concurrency/eventlet.py
+++ b/celery/concurrency/eventlet.py
@@ -1,8 +1,15 @@
 # -*- coding: utf-8 -*-
 """Eventlet execution pool."""
 from __future__ import absolute_import, unicode_literals
+
 import sys
+
+from kombu.asynchronous import timer as _timer  # noqa
 from kombu.five import monotonic
+
+from celery import signals  # noqa
+
+from . import base  # noqa
 
 __all__ = ['TaskPool']
 
@@ -19,14 +26,6 @@ for mod in (mod for mod in sys.modules if mod.startswith(RACE_MODS)):
         if getattr(mod, side, None):
             import warnings
             warnings.warn(RuntimeWarning(W_RACE % side))
-
-# idiotic pep8.py does not allow expressions before imports
-# so have to silence errors here
-from kombu.async import timer as _timer  # noqa
-
-from celery import signals  # noqa
-
-from . import base  # noqa
 
 
 def apply_target(target, args=(), kwargs={}, callback=None,

--- a/celery/concurrency/gevent.py
+++ b/celery/concurrency/gevent.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 """Gevent execution pool."""
 from __future__ import absolute_import, unicode_literals
-from kombu.async import timer as _timer
+
+from kombu.asynchronous import timer as _timer
 from kombu.five import monotonic
+
 from . import base
+
 try:
     from gevent import Timeout
 except ImportError:  # pragma: no cover

--- a/celery/concurrency/prefork.py
+++ b/celery/concurrency/prefork.py
@@ -7,13 +7,13 @@ from __future__ import absolute_import, unicode_literals
 
 import os
 
-from billiard.common import REMAP_SIGTERM, TERM_SIGNAME
 from billiard import forking_enable
-from billiard.pool import RUN, CLOSE, Pool as BlockingPool
+from billiard.common import REMAP_SIGTERM, TERM_SIGNAME
+from billiard.pool import CLOSE, RUN
+from billiard.pool import Pool as BlockingPool
 
-from celery import platforms
-from celery import signals
-from celery._state import set_default_app, _set_task_join_will_block
+from celery import platforms, signals
+from celery._state import _set_task_join_will_block, set_default_app
 from celery.app import trace
 from celery.concurrency.base import BasePool
 from celery.five import items

--- a/celery/concurrency/solo.py
+++ b/celery/concurrency/solo.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 """Single-threaded execution pool."""
 from __future__ import absolute_import, unicode_literals
+
 import os
+
 from .base import BasePool, apply_target
 
 __all__ = ['TaskPool']

--- a/celery/contrib/abortable.py
+++ b/celery/contrib/abortable.py
@@ -84,6 +84,7 @@ have it block until the task is finished.
    database backends.
 """
 from __future__ import absolute_import, unicode_literals
+
 from celery import Task
 from celery.result import AsyncResult
 

--- a/celery/contrib/migrate.py
+++ b/celery/contrib/migrate.py
@@ -3,11 +3,10 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 import socket
-
 from functools import partial
 from itertools import cycle, islice
 
-from kombu import eventloop, Queue
+from kombu import Queue, eventloop
 from kombu.common import maybe_declare
 from kombu.utils.encoding import ensure_bytes
 

--- a/celery/contrib/pytest.py
+++ b/celery/contrib/pytest.py
@@ -1,8 +1,11 @@
 """Fixtures and testing utilities for :pypi:`py.test <pytest>`."""
 from __future__ import absolute_import, unicode_literals
+
 import os
-import pytest
 from contextlib import contextmanager
+
+import pytest
+
 from .testing import worker
 from .testing.app import TestApp, setup_default_app
 

--- a/celery/contrib/rdb.py
+++ b/celery/contrib/rdb.py
@@ -42,12 +42,15 @@ Environment Variables
     base port.  The selected port will be logged by the worker.
 """
 from __future__ import absolute_import, print_function, unicode_literals
+
 import errno
 import os
 import socket
 import sys
 from pdb import Pdb
+
 from billiard.process import current_process
+
 from celery.five import range
 
 __all__ = [

--- a/celery/contrib/sphinx.py
+++ b/celery/contrib/sphinx.py
@@ -29,9 +29,12 @@ using `:task:proj.tasks.add` syntax.
 Use ``.. autotask::`` to manually document a task.
 """
 from __future__ import absolute_import, unicode_literals
+
 from inspect import formatargspec
+
 from sphinx.domains.python import PyModulelevel
 from sphinx.ext.autodoc import FunctionDocumenter
+
 from celery.app.task import BaseTask
 from celery.five import getfullargspec
 

--- a/celery/contrib/testing/app.py
+++ b/celery/contrib/testing/app.py
@@ -1,11 +1,13 @@
 """Create Celery app instances used for testing."""
 from __future__ import absolute_import, unicode_literals
+
 import weakref
 from contextlib import contextmanager
 from copy import deepcopy
+
 from kombu.utils.imports import symbol_by_name
-from celery import Celery
-from celery import _state
+
+from celery import Celery, _state
 
 #: Contains the default configuration values for the test app.
 DEFAULT_TEST_CONFIG = {

--- a/celery/contrib/testing/manager.py
+++ b/celery/contrib/testing/manager.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import socket
 import sys
-
 from collections import defaultdict
 from functools import partial
 from itertools import count

--- a/celery/contrib/testing/mocks.py
+++ b/celery/contrib/testing/mocks.py
@@ -1,7 +1,9 @@
 """Useful mocks for unit testing."""
 from __future__ import absolute_import, unicode_literals
+
 import numbers
 from datetime import datetime, timedelta
+
 try:
     from case import Mock
 except ImportError:

--- a/celery/contrib/testing/tasks.py
+++ b/celery/contrib/testing/tasks.py
@@ -1,5 +1,6 @@
 """Helper tasks for integration tests."""
 from __future__ import absolute_import, unicode_literals
+
 from celery import shared_task
 
 

--- a/celery/contrib/testing/worker.py
+++ b/celery/contrib/testing/worker.py
@@ -1,10 +1,12 @@
 """Embedded workers for integration tests."""
 from __future__ import absolute_import, unicode_literals
+
 import os
 import threading
 from contextlib import contextmanager
+
 from celery import worker
-from celery.result import allow_join_result, _set_task_join_will_block
+from celery.result import _set_task_join_will_block, allow_join_result
 from celery.utils.dispatch import Signal
 from celery.utils.nodenames import anon_nodename
 

--- a/celery/events/cursesmon.py
+++ b/celery/events/cursesmon.py
@@ -5,15 +5,13 @@ from __future__ import absolute_import, print_function, unicode_literals
 import curses
 import sys
 import threading
-
 from datetime import datetime
 from itertools import count
+from math import ceil
 from textwrap import wrap
 from time import time
-from math import ceil
 
-from celery import VERSION_BANNER
-from celery import states
+from celery import VERSION_BANNER, states
 from celery.app import app_or_default
 from celery.five import items, values
 from celery.utils.text import abbr, abbrtask

--- a/celery/events/dispatcher.py
+++ b/celery/events/dispatcher.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import, unicode_literals
 import os
 import threading
 import time
-
 from collections import defaultdict, deque
 
 from kombu import Producer

--- a/celery/events/dumper.py
+++ b/celery/events/dumper.py
@@ -5,8 +5,10 @@ This is a simple program that dumps events to the console
 as they happen.  Think of it like a `tcpdump` for Celery events.
 """
 from __future__ import absolute_import, print_function, unicode_literals
+
 import sys
 from datetime import datetime
+
 from celery.app import app_or_default
 from celery.utils.functional import LRUCache
 from celery.utils.time import humanize_seconds

--- a/celery/events/event.py
+++ b/celery/events/event.py
@@ -1,7 +1,9 @@
 """Creating events, and event exchange definition."""
 from __future__ import absolute_import, unicode_literals
+
 import time
 from copy import copy
+
 from kombu import Exchange
 
 __all__ = [

--- a/celery/events/receiver.py
+++ b/celery/events/receiver.py
@@ -2,7 +2,6 @@
 from __future__ import absolute_import, unicode_literals
 
 import time
-
 from operator import itemgetter
 
 from kombu import Queue

--- a/celery/events/snapshot.py
+++ b/celery/events/snapshot.py
@@ -8,14 +8,16 @@ implementation of this writing the snapshots to a database
 in :mod:`djcelery.snapshots` in the `django-celery` distribution.
 """
 from __future__ import absolute_import, print_function, unicode_literals
+
 from kombu.utils.limits import TokenBucket
+
 from celery import platforms
 from celery.app import app_or_default
-from celery.utils.timer2 import Timer
 from celery.utils.dispatch import Signal
 from celery.utils.imports import instantiate
 from celery.utils.log import get_logger
 from celery.utils.time import rate
+from celery.utils.timer2 import Timer
 
 __all__ = ['Polaroid', 'evcam']
 

--- a/celery/events/state.py
+++ b/celery/events/state.py
@@ -18,7 +18,6 @@ from __future__ import absolute_import, unicode_literals
 import bisect
 import sys
 import threading
-
 from collections import Callable, defaultdict
 from datetime import datetime
 from decimal import Decimal
@@ -101,6 +100,8 @@ class CallableDefaultdict(defaultdict):
 
     def __call__(self, *args, **kwargs):
         return self.fun(*args, **kwargs)
+
+
 Callable.register(CallableDefaultdict)  # noqa: E305
 
 

--- a/celery/exceptions.py
+++ b/celery/exceptions.py
@@ -48,12 +48,14 @@ Error Hierarchy
         - :exc:`~celery.exceptions.WorkerShutdown`
 """
 from __future__ import absolute_import, unicode_literals
+
 import numbers
-from .five import python_2_unicode_compatible, string_t
-from billiard.exceptions import (
-    SoftTimeLimitExceeded, TimeLimitExceeded, WorkerLostError, Terminated,
-)
+
+from billiard.exceptions import (SoftTimeLimitExceeded, Terminated,
+                                 TimeLimitExceeded, WorkerLostError)
 from kombu.exceptions import OperationalError
+
+from .five import python_2_unicode_compatible, string_t
 
 __all__ = [
     # Warnings
@@ -159,6 +161,8 @@ class Retry(TaskPredicate):
 
     def __reduce__(self):
         return self.__class__, (self.message, self.excs, self.when)
+
+
 RetryTaskError = Retry  # noqa: E305 XXX compat
 
 
@@ -242,6 +246,8 @@ class CDeprecationWarning(DeprecationWarning):
 
 class WorkerTerminate(SystemExit):
     """Signals that the worker should terminate immediately."""
+
+
 SystemTerminate = WorkerTerminate  # noqa: E305 XXX compat
 
 

--- a/celery/five.py
+++ b/celery/five.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 """Python 2/3 compatibility utilities."""
 from __future__ import absolute_import, unicode_literals
+
 import sys
+
 import vine.five
+
 sys.modules[__name__] = vine.five

--- a/celery/fixups/django.py
+++ b/celery/fixups/django.py
@@ -4,15 +4,13 @@ from __future__ import absolute_import, unicode_literals
 import os
 import sys
 import warnings
+from datetime import datetime
+from importlib import import_module
 
 from kombu.utils.imports import symbol_by_name
 from kombu.utils.objects import cached_property
 
-from datetime import datetime
-from importlib import import_module
-
-from celery import _state
-from celery import signals
+from celery import _state, signals
 from celery.exceptions import FixupWarning, ImproperlyConfigured
 
 __all__ = ['DjangoFixup', 'fixup']

--- a/celery/loaders/app.py
+++ b/celery/loaders/app.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """The default loader used with custom app instances."""
 from __future__ import absolute_import, unicode_literals
+
 from .base import BaseLoader
 
 __all__ = ['AppLoader']

--- a/celery/loaders/base.py
+++ b/celery/loaders/base.py
@@ -7,7 +7,6 @@ import importlib
 import os
 import re
 import sys
-
 from datetime import datetime
 
 from kombu.utils import json
@@ -17,9 +16,8 @@ from celery import signals
 from celery.five import reraise, string_t
 from celery.utils.collections import DictAttribute, force_mapping
 from celery.utils.functional import maybe_list
-from celery.utils.imports import (
-    import_from_cwd, symbol_by_name, NotAPackage, find_module,
-)
+from celery.utils.imports import (NotAPackage, find_module, import_from_cwd,
+                                  symbol_by_name)
 
 __all__ = ['BaseLoader']
 

--- a/celery/loaders/default.py
+++ b/celery/loaders/default.py
@@ -1,11 +1,14 @@
 # -*- coding: utf-8 -*-
 """The default loader used when no custom app has been initialized."""
 from __future__ import absolute_import, unicode_literals
+
 import os
 import warnings
+
 from celery.exceptions import NotConfigured
 from celery.utils.collections import DictAttribute
 from celery.utils.serialization import strtobool
+
 from .base import BaseLoader
 
 __all__ = ['Loader', 'DEFAULT_CONFIG_MODULE']

--- a/celery/local.py
+++ b/celery/local.py
@@ -7,11 +7,13 @@ soon as possible, and that shall not load any third party modules.
 Parts of this module is Copyright by Werkzeug Team.
 """
 from __future__ import absolute_import, unicode_literals
+
 import operator
 import sys
 from functools import reduce
 from importlib import import_module
 from types import ModuleType
+
 from .five import bytes_if_py2, items, string, string_t
 
 __all__ = ['Proxy', 'PromiseProxy', 'try_import', 'maybe_evaluate']

--- a/celery/platforms.py
+++ b/celery/platforms.py
@@ -15,18 +15,17 @@ import platform as _platform
 import signal as _signal
 import sys
 import warnings
-
 from collections import namedtuple
+from contextlib import contextmanager
 
-from billiard.compat import get_fdmax, close_open_fds
+from billiard.compat import close_open_fds, get_fdmax
 # fileno used to be in this module
 from kombu.utils.compat import maybe_fileno
 from kombu.utils.encoding import safe_str
-from contextlib import contextmanager
 
 from .exceptions import SecurityError
-from .local import try_import
 from .five import items, reraise, string_t
+from .local import try_import
 
 try:
     from billiard.process import current_process
@@ -229,6 +228,8 @@ class Pidfile(object):
                     "Inconsistency: Pidfile content doesn't match at re-read")
         finally:
             rfh.close()
+
+
 PIDFile = Pidfile  # noqa: E305 XXX compat alias
 
 

--- a/celery/result.py
+++ b/celery/result.py
@@ -3,7 +3,6 @@
 from __future__ import absolute_import, unicode_literals
 
 import time
-
 from collections import OrderedDict, deque
 from contextlib import contextmanager
 from copy import copy
@@ -11,14 +10,12 @@ from copy import copy
 from kombu.utils.objects import cached_property
 from vine import Thenable, barrier, promise
 
-from . import current_app
-from . import states
+from . import current_app, states
 from ._state import _set_task_join_will_block, task_join_will_block
 from .app import app_or_default
 from .exceptions import ImproperlyConfigured, IncompleteStream, TimeoutError
-from .five import (
-    items, python_2_unicode_compatible, range, string_t, monotonic,
-)
+from .five import (items, monotonic, python_2_unicode_compatible, range,
+                   string_t)
 from .utils import deprecated
 from .utils.graph import DependencyGraph, GraphFormatter
 

--- a/celery/schedules.py
+++ b/celery/schedules.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import, unicode_literals
 
 import numbers
 import re
-
 from bisect import bisect, bisect_left
 from collections import Iterable, namedtuple
 from datetime import datetime, timedelta
@@ -14,10 +13,8 @@ from kombu.utils.objects import cached_property
 from . import current_app
 from .five import python_2_unicode_compatible, range, string_t
 from .utils.collections import AttributeDict
-from .utils.time import (
-    weekday, maybe_timedelta, remaining, humanize_seconds,
-    timezone, maybe_make_aware, ffwd, localize
-)
+from .utils.time import (ffwd, humanize_seconds, localize, maybe_make_aware,
+                         maybe_timedelta, remaining, timezone, weekday)
 
 __all__ = [
     'ParseException', 'schedule', 'crontab', 'crontab_parser',
@@ -477,15 +474,20 @@ class crontab(BaseSchedule):
                 return True
             return False
 
+        def is_before_last_run(year, month, day):
+            return self.maybe_make_aware(datetime(year,
+                                                  month,
+                                                  day)) < last_run_at
+
         def roll_over():
             for _ in range(2000):
                 flag = (datedata.dom == len(days_of_month) or
                         day_out_of_range(datedata.year,
                                          months_of_year[datedata.moy],
                                          days_of_month[datedata.dom]) or
-                        (self.maybe_make_aware(datetime(datedata.year,
-                         months_of_year[datedata.moy],
-                         days_of_month[datedata.dom])) < last_run_at))
+                        (is_before_last_run(datedata.year,
+                                            months_of_year[datedata.moy],
+                                            days_of_month[datedata.dom])))
 
                 if flag:
                     datedata.dom = 0

--- a/celery/security/certificate.py
+++ b/celery/security/certificate.py
@@ -1,11 +1,15 @@
 # -*- coding: utf-8 -*-
 """X.509 certificates."""
 from __future__ import absolute_import, unicode_literals
+
 import glob
 import os
+
 from kombu.utils.encoding import bytes_to_str
+
 from celery.exceptions import SecurityError
 from celery.five import values
+
 from .utils import crypto, reraise_errors
 
 __all__ = ['Certificate', 'CertStore', 'FSCertStore']

--- a/celery/security/key.py
+++ b/celery/security/key.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 """Private keys for the security serializer."""
 from __future__ import absolute_import, unicode_literals
+
 from kombu.utils.encoding import ensure_bytes
+
 from .utils import crypto, reraise_errors
 
 __all__ = ['PrivateKey']

--- a/celery/security/serialization.py
+++ b/celery/security/serialization.py
@@ -2,11 +2,11 @@
 """Secure serializer."""
 from __future__ import absolute_import, unicode_literals
 
-from kombu.serialization import registry, dumps, loads
-from kombu.utils.encoding import bytes_to_str, str_to_bytes, ensure_bytes
+from kombu.serialization import dumps, loads, registry
+from kombu.utils.encoding import bytes_to_str, ensure_bytes, str_to_bytes
 
 from celery.five import bytes_if_py2
-from celery.utils.serialization import b64encode, b64decode
+from celery.utils.serialization import b64decode, b64encode
 
 from .certificate import Certificate, FSCertStore
 from .key import PrivateKey

--- a/celery/security/utils.py
+++ b/celery/security/utils.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
 """Utilities used by the message signing serializer."""
 from __future__ import absolute_import, unicode_literals
+
 import sys
 from contextlib import contextmanager
+
 from celery.exceptions import SecurityError
 from celery.five import reraise
+
 try:
     from OpenSSL import crypto
 except ImportError:  # pragma: no cover

--- a/celery/signals.py
+++ b/celery/signals.py
@@ -12,6 +12,7 @@ functions are called whenever a signal is called.
     :ref:`signals` for more information.
 """
 from __future__ import absolute_import, unicode_literals
+
 from .utils.dispatch import Signal
 
 __all__ = [

--- a/celery/task/base.py
+++ b/celery/task/base.py
@@ -7,9 +7,13 @@ This contains the backward compatible Task class used in the old API,
 and shouldn't be used in new applications.
 """
 from __future__ import absolute_import, unicode_literals
+
 from kombu import Exchange
+
 from celery import current_app
-from celery.app.task import Context, Task as BaseTask, _reprtask
+from celery.app.task import Context
+from celery.app.task import Task as BaseTask
+from celery.app.task import _reprtask
 from celery.five import python_2_unicode_compatible, with_metaclass
 from celery.local import Proxy, class_property, reclassmethod
 from celery.schedules import maybe_schedule

--- a/celery/utils/abstract.py
+++ b/celery/utils/abstract.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 """Abstract classes."""
 from __future__ import absolute_import, unicode_literals
+
 from abc import ABCMeta, abstractmethod, abstractproperty
 from collections import Callable
+
 from celery.five import with_metaclass
 
 __all__ = ['CallableTask', 'CallableSignature']

--- a/celery/utils/collections.py
+++ b/celery/utils/collections.py
@@ -4,15 +4,14 @@ from __future__ import absolute_import, unicode_literals
 
 import sys
 import time
-
-from collections import (
-    Callable, Mapping, MutableMapping, MutableSet, Sequence,
-    OrderedDict as _OrderedDict, deque,
-)
-from heapq import heapify, heappush, heappop
+from collections import Callable, Mapping, MutableMapping, MutableSet
+from collections import OrderedDict as _OrderedDict
+from collections import Sequence, deque
+from heapq import heapify, heappop, heappush
 from itertools import chain, count
 
-from celery.five import Empty, items, keys, python_2_unicode_compatible, values
+from celery.five import (Empty, items, keys, python_2_unicode_compatible,
+                         values)
 
 from .functional import first, uniq
 from .text import match_case
@@ -229,6 +228,8 @@ class DictAttribute(object):
         def values(self):
             # type: () -> List[Any]
             return list(self._iterate_values())
+
+
 MutableMapping.register(DictAttribute)  # noqa: E305
 
 
@@ -707,6 +708,8 @@ class LimitedSet(object):
         # type: () -> float
         """Compute how much is heap bigger than data [percents]."""
         return len(self._heap) * 100 / max(len(self._data), 1) - 100
+
+
 MutableSet.register(LimitedSet)  # noqa: E305
 
 
@@ -809,6 +812,8 @@ class Messagebuffer(Evictable):
     def _evictcount(self):
         # type: () -> int
         return len(self)
+
+
 Sequence.register(Messagebuffer)  # noqa: E305
 
 

--- a/celery/utils/debug.py
+++ b/celery/utils/debug.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import, print_function, unicode_literals
 import os
 import sys
 import traceback
-
 from contextlib import contextmanager
 from functools import partial
 from pprint import pprint

--- a/celery/utils/deprecated.py
+++ b/celery/utils/deprecated.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 """Deprecation utilities."""
 from __future__ import absolute_import, print_function, unicode_literals
+
 import warnings
+
 from vine.utils import wraps
-from celery.exceptions import CPendingDeprecationWarning, CDeprecationWarning
+
+from celery.exceptions import CDeprecationWarning, CPendingDeprecationWarning
 
 __all__ = ['Callable', 'Property', 'warn']
 

--- a/celery/utils/dispatch/signal.py
+++ b/celery/utils/dispatch/signal.py
@@ -1,15 +1,18 @@
 # -*- coding: utf-8 -*-
 """Implementation of the Observer pattern."""
 from __future__ import absolute_import, unicode_literals
+
 import sys
 import threading
-import weakref
 import warnings
+import weakref
+
 from celery.exceptions import CDeprecationWarning
 from celery.five import python_2_unicode_compatible, range, text_t
 from celery.local import PromiseProxy, Proxy
 from celery.utils.functional import fun_accepts_kwargs
 from celery.utils.log import get_logger
+
 try:
     from weakref import WeakMethod
 except ImportError:

--- a/celery/utils/dispatch/weakref_backports.py
+++ b/celery/utils/dispatch/weakref_backports.py
@@ -11,6 +11,7 @@ The following changes were made to the original sources during backporting:
 * Removed ``from None`` when raising exceptions.
 """
 from __future__ import absolute_import, unicode_literals
+
 from weakref import ref
 
 

--- a/celery/utils/encoding.py
+++ b/celery/utils/encoding.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 """**DEPRECATED**: This module has moved to :mod:`kombu.utils.encoding`."""
 from __future__ import absolute_import, unicode_literals
-from kombu.utils.encoding import (  # noqa
-    default_encode, default_encoding, bytes_t, bytes_to_str, str_t,
-    str_to_bytes, ensure_bytes, from_utf8, safe_str, safe_repr,
-)
+
+from kombu.utils.encoding import (bytes_t, bytes_to_str,  # noqa
+                                  default_encode, default_encoding,
+                                  ensure_bytes, from_utf8, safe_repr,
+                                  safe_str, str_t, str_to_bytes)

--- a/celery/utils/functional.py
+++ b/celery/utils/functional.py
@@ -4,14 +4,11 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import inspect
 import sys
-
 from functools import partial
 from itertools import chain, islice
 
-from kombu.utils.functional import (
-    LRUCache, dictfilter, lazy, maybe_evaluate, memoize,
-    is_list, maybe_list,
-)
+from kombu.utils.functional import (LRUCache, dictfilter, is_list, lazy,
+                                    maybe_evaluate, maybe_list, memoize)
 from vine import promise
 
 from celery.five import UserList, getfullargspec, range

--- a/celery/utils/graph.py
+++ b/celery/utils/graph.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 """Dependency graph implementation."""
 from __future__ import absolute_import, print_function, unicode_literals
+
 from collections import Counter
 from textwrap import dedent
-from kombu.utils.encoding import safe_str, bytes_to_str
+
+from kombu.utils.encoding import bytes_to_str, safe_str
+
 from celery.five import items, python_2_unicode_compatible
 
 __all__ = ['DOT', 'CycleError', 'DependencyGraph', 'GraphFormatter']

--- a/celery/utils/imports.py
+++ b/celery/utils/imports.py
@@ -1,13 +1,16 @@
 # -*- coding: utf-8 -*-
 """Utilities related to importing modules and symbols by name."""
 from __future__ import absolute_import, unicode_literals
+
 import imp as _imp
 import importlib
 import os
 import sys
 import warnings
 from contextlib import contextmanager
+
 from kombu.utils.imports import symbol_by_name
+
 from celery.five import reload
 
 #: Billiard sets this when execv is enabled.

--- a/celery/utils/iso8601.py
+++ b/celery/utils/iso8601.py
@@ -33,8 +33,10 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 from __future__ import absolute_import, unicode_literals
+
 import re
 from datetime import datetime
+
 from pytz import FixedOffset
 
 __all__ = ['parse_iso8601']

--- a/celery/utils/log.py
+++ b/celery/utils/log.py
@@ -8,10 +8,11 @@ import os
 import sys
 import threading
 import traceback
-
 from contextlib import contextmanager
+
 from kombu.five import values
-from kombu.log import get_logger as _get_logger, LOG_LEVELS
+from kombu.log import LOG_LEVELS
+from kombu.log import get_logger as _get_logger
 from kombu.utils.encoding import safe_str
 
 from celery.five import string_t, text_t

--- a/celery/utils/nodenames.py
+++ b/celery/utils/nodenames.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
 """Worker name utilities."""
 from __future__ import absolute_import, unicode_literals
+
 import os
 import socket
 from functools import partial
+
 from kombu.entity import Exchange, Queue
+
 from .functional import memoize
 from .text import simple_format
 

--- a/celery/utils/objects.py
+++ b/celery/utils/objects.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Object related utilities, including introspection, etc."""
 from __future__ import absolute_import, unicode_literals
+
 from functools import reduce
 
 __all__ = ['Bunch', 'FallbackContext', 'getitem_property', 'mro_lookup']

--- a/celery/utils/saferepr.py
+++ b/celery/utils/saferepr.py
@@ -14,9 +14,7 @@ from __future__ import absolute_import, unicode_literals
 
 import sys
 import traceback
-
 from collections import deque, namedtuple
-
 from decimal import Decimal
 from itertools import chain
 from numbers import Number

--- a/celery/utils/serialization.py
+++ b/celery/utils/serialization.py
@@ -5,17 +5,16 @@ from __future__ import absolute_import, unicode_literals
 import datetime
 import numbers
 import sys
-
-from base64 import b64encode as base64encode, b64decode as base64decode
+from base64 import b64decode as base64decode
+from base64 import b64encode as base64encode
 from functools import partial
 from inspect import getmro
 from itertools import takewhile
 
 from kombu.utils.encoding import bytes_to_str, str_to_bytes
 
-from celery.five import (
-    bytes_if_py2, python_2_unicode_compatible, items, reraise, string_t,
-)
+from celery.five import (bytes_if_py2, items, python_2_unicode_compatible,
+                         reraise, string_t)
 
 from .encoding import safe_repr
 

--- a/celery/utils/sysinfo.py
+++ b/celery/utils/sysinfo.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 """System information utilities."""
 from __future__ import absolute_import, unicode_literals
+
 import os
 from math import ceil
+
 from kombu.utils.objects import cached_property
 
 __all__ = ['load_average', 'df']

--- a/celery/utils/term.py
+++ b/celery/utils/term.py
@@ -1,12 +1,14 @@
 # -*- coding: utf-8 -*-
 """Terminals and colors."""
 from __future__ import absolute_import, unicode_literals
+
 import base64
 import codecs
 import os
-import sys
 import platform
+import sys
 from functools import reduce
+
 from celery.five import python_2_unicode_compatible, string
 from celery.platforms import isatty
 

--- a/celery/utils/text.py
+++ b/celery/utils/text.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 """Text formatting utilities."""
 from __future__ import absolute_import, unicode_literals
+
 import re
 from collections import Callable
 from functools import partial
-from textwrap import fill
 from pprint import pformat
+from textwrap import fill
+
 from celery.five import string_t
 
 __all__ = [

--- a/celery/utils/threads.py
+++ b/celery/utils/threads.py
@@ -7,11 +7,10 @@ import socket
 import sys
 import threading
 import traceback
-
 from contextlib import contextmanager
 
-from celery.local import Proxy
 from celery.five import THREAD_TIMEOUT_MAX, items, python_2_unicode_compatible
+from celery.local import Proxy
 
 try:
     from greenlet import getcurrent as get_ident

--- a/celery/utils/time.py
+++ b/celery/utils/time.py
@@ -6,14 +6,13 @@ import numbers
 import os
 import sys
 import time as _time
-
 from calendar import monthrange
 from datetime import date, datetime, timedelta, tzinfo
 
 from kombu.utils.functional import reprcall
 from kombu.utils.objects import cached_property
-
-from pytz import timezone as _timezone, AmbiguousTimeError, FixedOffset
+from pytz import AmbiguousTimeError, FixedOffset
+from pytz import timezone as _timezone
 
 from celery.five import python_2_unicode_compatible, string_t
 
@@ -360,7 +359,7 @@ class ffwd(object):
         month = self.month or other.month
         day = min(monthrange(year, month)[1], self.day or other.day)
         ret = other.replace(**dict(dictfilter(self._fields()),
-                            year=year, month=month, day=day))
+                                   year=year, month=month, day=day))
         if self.weekday is not None:
             ret += timedelta(days=(7 - ret.weekday() + self.weekday) % 7)
         return ret + timedelta(days=self.days)

--- a/celery/utils/timer2.py
+++ b/celery/utils/timer2.py
@@ -3,20 +3,21 @@
 
 .. note::
     This is used for the thread-based worker only,
-    not for amqp/redis/sqs/qpid where :mod:`kombu.async.timer` is used.
+    not for amqp/redis/sqs/qpid where :mod:`kombu.asynchronous.timer` is used.
 """
 from __future__ import absolute_import, print_function, unicode_literals
 
 import os
 import sys
 import threading
-
 from itertools import count
 from time import sleep
 
-from celery.five import THREAD_TIMEOUT_MAX
+from kombu.asynchronous.timer import Entry
+from kombu.asynchronous.timer import Timer as Schedule
+from kombu.asynchronous.timer import logger, to_timestamp
 
-from kombu.async.timer import Entry, Timer as Schedule, to_timestamp, logger
+from celery.five import THREAD_TIMEOUT_MAX
 
 TIMER_DEBUG = os.environ.get('TIMER_DEBUG')
 

--- a/celery/worker/autoscale.py
+++ b/celery/worker/autoscale.py
@@ -12,10 +12,9 @@ from __future__ import absolute_import, unicode_literals
 
 import os
 import threading
-
 from time import sleep
 
-from kombu.async.semaphore import DummyLock
+from kombu.asynchronous.semaphore import DummyLock
 
 from celery import bootsteps
 from celery.five import monotonic

--- a/celery/worker/components.py
+++ b/celery/worker/components.py
@@ -5,9 +5,10 @@ from __future__ import absolute_import, unicode_literals
 import atexit
 import warnings
 
-from kombu.async import Hub as _Hub, get_event_loop, set_event_loop
-from kombu.async.semaphore import DummyLock, LaxBoundedSemaphore
-from kombu.async.timer import Timer as _Timer
+from kombu.asynchronous import Hub as _Hub
+from kombu.asynchronous import get_event_loop, set_event_loop
+from kombu.asynchronous.semaphore import DummyLock, LaxBoundedSemaphore
+from kombu.asynchronous.timer import Timer as _Timer
 
 from celery import bootsteps
 from celery._state import _set_task_join_will_block

--- a/celery/worker/consumer/agent.py
+++ b/celery/worker/consumer/agent.py
@@ -1,6 +1,8 @@
 """Celery + :pypi:`cell` integration."""
 from __future__ import absolute_import, unicode_literals
+
 from celery import bootsteps
+
 from .connection import Connection
 
 __all__ = ['Agent']

--- a/celery/worker/consumer/connection.py
+++ b/celery/worker/consumer/connection.py
@@ -1,6 +1,8 @@
 """Consumer Broker Connection Bootstep."""
 from __future__ import absolute_import, unicode_literals
+
 from kombu.common import ignore_errors
+
 from celery import bootsteps
 from celery.utils.log import get_logger
 

--- a/celery/worker/consumer/consumer.py
+++ b/celery/worker/consumer/consumer.py
@@ -10,20 +10,18 @@ from __future__ import absolute_import, unicode_literals
 import errno
 import logging
 import os
-
 from collections import defaultdict
 from time import sleep
 
 from billiard.common import restart_state
 from billiard.exceptions import RestartFreqExceeded
-from kombu.async.semaphore import DummyLock
+from kombu.asynchronous.semaphore import DummyLock
 from kombu.utils.compat import _detect_environment
-from kombu.utils.encoding import safe_repr, bytes_t
+from kombu.utils.encoding import bytes_t, safe_repr
 from kombu.utils.limits import TokenBucket
 from vine import ppartial, promise
 
-from celery import bootsteps
-from celery import signals
+from celery import bootsteps, signals
 from celery.app.trace import build_tracer
 from celery.exceptions import InvalidTaskError, NotRegistered
 from celery.five import buffer_t, items, python_2_unicode_compatible, values
@@ -33,11 +31,9 @@ from celery.utils.nodenames import gethostname
 from celery.utils.objects import Bunch
 from celery.utils.text import truncate
 from celery.utils.time import humanize_seconds, rate
-
 from celery.worker import loops
-from celery.worker.state import (
-    task_reserved, maybe_shutdown, reserved_requests,
-)
+from celery.worker.state import (maybe_shutdown, reserved_requests,
+                                 task_reserved)
 
 __all__ = ['Consumer', 'Evloop', 'dump_body']
 

--- a/celery/worker/consumer/control.py
+++ b/celery/worker/consumer/control.py
@@ -5,9 +5,11 @@
 The actual commands are implemented in :mod:`celery.worker.control`.
 """
 from __future__ import absolute_import, unicode_literals
+
 from celery import bootsteps
 from celery.utils.log import get_logger
 from celery.worker import pidbox
+
 from .tasks import Tasks
 
 __all__ = ['Control']

--- a/celery/worker/consumer/events.py
+++ b/celery/worker/consumer/events.py
@@ -3,8 +3,11 @@
 ``Events`` -> :class:`celery.events.EventDispatcher`.
 """
 from __future__ import absolute_import, unicode_literals
+
 from kombu.common import ignore_errors
+
 from celery import bootsteps
+
 from .connection import Connection
 
 __all__ = ['Events']

--- a/celery/worker/consumer/gossip.py
+++ b/celery/worker/consumer/gossip.py
@@ -7,7 +7,7 @@ from heapq import heappush
 from operator import itemgetter
 
 from kombu import Consumer
-from kombu.async.semaphore import DummyLock
+from kombu.asynchronous.semaphore import DummyLock
 
 from celery import bootsteps
 from celery.five import values

--- a/celery/worker/consumer/heart.py
+++ b/celery/worker/consumer/heart.py
@@ -1,7 +1,9 @@
 """Worker Event Heartbeat Bootstep."""
 from __future__ import absolute_import, unicode_literals
+
 from celery import bootsteps
 from celery.worker import heartbeat
+
 from .events import Events
 
 __all__ = ['Heart']

--- a/celery/worker/consumer/mingle.py
+++ b/celery/worker/consumer/mingle.py
@@ -1,8 +1,10 @@
 """Worker <-> Worker Sync at startup (Bootstep)."""
 from __future__ import absolute_import, unicode_literals
+
 from celery import bootsteps
 from celery.five import items
 from celery.utils.log import get_logger
+
 from .events import Events
 
 __all__ = ['Mingle']

--- a/celery/worker/consumer/tasks.py
+++ b/celery/worker/consumer/tasks.py
@@ -1,8 +1,11 @@
 """Worker Task Consumer Bootstep."""
 from __future__ import absolute_import, unicode_literals
+
 from kombu.common import QoS, ignore_errors
+
 from celery import bootsteps
 from celery.utils.log import get_logger
+
 from .mingle import Mingle
 
 __all__ = ['Tasks']

--- a/celery/worker/control.py
+++ b/celery/worker/control.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import, unicode_literals
 
 import io
 import tempfile
-
 from collections import namedtuple
 
 from billiard.common import TERM_SIGNAME

--- a/celery/worker/heartbeat.py
+++ b/celery/worker/heartbeat.py
@@ -5,8 +5,10 @@ This is the internal thread responsible for sending heartbeat events
 at regular intervals (may not be an actual thread).
 """
 from __future__ import absolute_import, unicode_literals
+
 from celery.signals import heartbeat_sent
 from celery.utils.sysinfo import load_average
+
 from .state import SOFTWARE_INFO, active_requests, all_total_count
 
 __all__ = ['Heart']
@@ -16,7 +18,7 @@ class Heart(object):
     """Timer sending heartbeats at regular intervals.
 
     Arguments:
-        timer (kombu.async.timer.Timer): Timer to use.
+        timer (kombu.asynchronous.timer.Timer): Timer to use.
         eventer (celery.events.EventDispatcher): Event dispatcher
             to use.
         interval (float): Time in seconds between sending

--- a/celery/worker/loops.py
+++ b/celery/worker/loops.py
@@ -1,10 +1,13 @@
 """The consumers highly-optimized inner loop."""
 from __future__ import absolute_import, unicode_literals
+
 import errno
 import socket
+
 from celery import bootsteps
-from celery.exceptions import WorkerShutdown, WorkerTerminate, WorkerLostError
+from celery.exceptions import WorkerLostError, WorkerShutdown, WorkerTerminate
 from celery.utils.log import get_logger
+
 from . import state
 
 __all__ = ['asynloop', 'synloop']

--- a/celery/worker/pidbox.py
+++ b/celery/worker/pidbox.py
@@ -1,12 +1,16 @@
 """Worker Pidbox (remote control)."""
 from __future__ import absolute_import, unicode_literals
+
 import socket
 import threading
+
 from kombu.common import ignore_errors
 from kombu.utils.encoding import safe_str
+
 from celery.utils.collections import AttributeDict
 from celery.utils.functional import pass1
 from celery.utils.log import get_logger
+
 from . import control
 
 __all__ = ['Pidbox', 'gPidbox']

--- a/celery/worker/request.py
+++ b/celery/worker/request.py
@@ -8,7 +8,6 @@ from __future__ import absolute_import, unicode_literals
 
 import logging
 import sys
-
 from datetime import datetime
 from weakref import ref
 
@@ -18,18 +17,16 @@ from kombu.utils.objects import cached_property
 
 from celery import signals
 from celery.app.trace import trace_task, trace_task_ret
-from celery.exceptions import (
-    Ignore, TaskRevokedError, InvalidTaskError,
-    SoftTimeLimitExceeded, TimeLimitExceeded,
-    WorkerLostError, Terminated, Retry, Reject,
-)
+from celery.exceptions import (Ignore, InvalidTaskError, Reject, Retry,
+                               SoftTimeLimitExceeded, TaskRevokedError,
+                               Terminated, TimeLimitExceeded, WorkerLostError)
 from celery.five import python_2_unicode_compatible, string
 from celery.platforms import signals as _signals
 from celery.utils.functional import maybe, noop
 from celery.utils.log import get_logger
 from celery.utils.nodenames import gethostname
-from celery.utils.time import maybe_iso8601, timezone, maybe_make_aware
 from celery.utils.serialization import get_pickled_exception
+from celery.utils.time import maybe_iso8601, maybe_make_aware, timezone
 
 from . import state
 
@@ -53,6 +50,8 @@ def __optimize__():
     global _does_info
     _does_debug = logger.isEnabledFor(logging.DEBUG)
     _does_info = logger.isEnabledFor(logging.INFO)
+
+
 __optimize__()  # noqa: E305
 
 # Localize

--- a/celery/worker/state.py
+++ b/celery/worker/state.py
@@ -7,9 +7,9 @@ statistics, and revoked tasks.
 from __future__ import absolute_import, print_function, unicode_literals
 
 import os
-import sys
 import platform
 import shelve
+import sys
 import weakref
 import zlib
 

--- a/celery/worker/strategy.py
+++ b/celery/worker/strategy.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, unicode_literals
 
 import logging
 
-from kombu.async.timer import to_timestamp
+from kombu.asynchronous.timer import to_timestamp
 from kombu.five import buffer_t
 
 from celery.exceptions import InvalidTaskError

--- a/celery/worker/worker.py
+++ b/celery/worker/worker.py
@@ -16,30 +16,32 @@ from __future__ import absolute_import, unicode_literals
 
 import os
 import sys
-try:
-    import resource
-except ImportError:  # pragma: no cover
-    resource = None  # noqa
 
 from billiard import cpu_count
 from kombu.utils.compat import detect_environment
 
 from celery import bootsteps
-from celery.bootsteps import RUN, TERMINATE
 from celery import concurrency as _concurrency
 from celery import signals
-from celery.exceptions import (
-    ImproperlyConfigured, WorkerTerminate, TaskRevokedError,
-)
+from celery.bootsteps import RUN, TERMINATE
+from celery.exceptions import (ImproperlyConfigured, TaskRevokedError,
+                               WorkerTerminate)
 from celery.five import python_2_unicode_compatible, values
 from celery.platforms import EX_FAILURE, create_pidlock
 from celery.utils.imports import reload_from_cwd
-from celery.utils.log import mlevel, worker_logger as logger
+from celery.utils.log import mlevel
+from celery.utils.log import worker_logger as logger
 from celery.utils.nodenames import default_nodename, worker_direct
 from celery.utils.text import str_to_list
 from celery.utils.threads import default_socket_timeout
 
 from . import state
+
+try:
+    import resource
+except ImportError:  # pragma: no cover
+    resource = None  # noqa
+
 
 __all__ = ['WorkController']
 
@@ -238,7 +240,7 @@ class WorkController(object):
 
     def should_use_eventloop(self):
         return (detect_environment() == 'default' and
-                self._conninfo.transport.implements.async and
+                self._conninfo.transport.implements.asynchronous and
                 not self.app.IS_WINDOWS)
 
     def stop(self, in_sighandler=False, exitcode=None):

--- a/docs/includes/introduction.txt
+++ b/docs/includes/introduction.txt
@@ -1,4 +1,4 @@
-:Version: 4.1.0 (latentcall)
+:Version: 4.1.1 (latentcall)
 :Web: http://celeryproject.org/
 :Download: https://pypi.python.org/pypi/celery/
 :Source: https://github.com/celery/celery/

--- a/docs/userguide/configuration.rst
+++ b/docs/userguide/configuration.rst
@@ -2393,7 +2393,7 @@ Name of the consumer class used by the worker.
 ``worker_timer``
 ~~~~~~~~~~~~~~~~
 
-Default: ``"kombu.async.hub.timer:Timer"``.
+Default: ``"kombu.asynchronous.hub.timer:Timer"``.
 
 Name of the ETA scheduler class used by the worker.
 Default is or set by the pool implementation.

--- a/docs/userguide/extending.rst
+++ b/docs/userguide/extending.rst
@@ -148,7 +148,7 @@ Attributes
 
 .. attribute:: hub
 
-    Event loop object (:class:`~kombu.async.Hub`). You can use
+    Event loop object (:class:`~kombu.asynchronous.Hub`). You can use
     this to register callbacks in the event loop.
 
     This is only supported by async I/O enabled transports (amqp, redis),
@@ -179,7 +179,7 @@ Attributes
 
 .. attribute:: timer
 
-    :class:`~kombu.async.timer.Timer` used to schedule functions.
+    :class:`~kombu.asynchronous.timer.Timer` used to schedule functions.
 
     Your worker bootstep must require the Timer bootstep to use this:
 
@@ -349,7 +349,7 @@ Attributes
 
 .. attribute:: hub
 
-    Event loop object (:class:`~kombu.async.Hub`). You can use
+    Event loop object (:class:`~kombu.asynchronous.Hub`). You can use
     this to register callbacks in the event loop.
 
     This is only supported by async I/O enabled transports (amqp, redis),
@@ -873,7 +873,7 @@ Worker API
 ==========
 
 
-:class:`~kombu.async.Hub` - The workers async event loop
+:class:`~kombu.asynchronous.Hub` - The workers async event loop
 --------------------------------------------------------
 :supported transports: amqp, redis
 

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,3 +1,3 @@
 pytz>dev
 billiard>=3.5.0.2,<3.6.0
-kombu>=4.0.2,<5.0
+kombu>=4.2.0,<5.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,2 +1,2 @@
 case>=1.3.1
-pytest>=3.0
+pytest>=3.0,<3.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ all_files = 1
 [flake8]
 # classes can be lowercase, arguments and variables can be uppercase
 # whenever it makes the code more readable.
-ignore = N806, N802, N801, N803
+ignore = N806, N802, N801, N803, E741, E742, E722
 
 [pep257]
 ignore = D102,D104,D203,D105,D213

--- a/t/benchmarks/bench_worker.py
+++ b/t/benchmarks/bench_worker.py
@@ -3,14 +3,16 @@ from __future__ import absolute_import, print_function, unicode_literals
 import os
 import sys
 
+from kombu.five import monotonic  # noqa
+
+from celery import Celery  # noqa
+from celery.five import range  # noqa
+
 os.environ.update(
     NOSETPS='yes',
     USE_FAST_LOCALS='yes',
 )
 
-from celery import Celery  # noqa
-from celery.five import range  # noqa
-from kombu.five import monotonic  # noqa
 
 DEFAULT_ITS = 40000
 

--- a/t/distro/test_CI_reqs.py
+++ b/t/distro/test_CI_reqs.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import, unicode_literals
+
 import os
 import pprint
+
 import pytest
 
 

--- a/t/integration/conftest.py
+++ b/t/integration/conftest.py
@@ -1,7 +1,10 @@
 from __future__ import absolute_import, unicode_literals
+
 import os
-import pytest
 from functools import wraps
+
+import pytest
+
 from celery.contrib.testing.manager import Manager
 
 TEST_BROKER = os.environ.get('TEST_BROKER', 'pyamqp://')

--- a/t/integration/tasks.py
+++ b/t/integration/tasks.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
+
 from time import sleep
-from celery import shared_task, group
+
+from celery import group, shared_task
 from celery.utils.log import get_task_logger
 
 logger = get_task_logger(__name__)

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -1,9 +1,12 @@
 from __future__ import absolute_import, unicode_literals
+
 import pytest
 from redis import StrictRedis
+
 from celery import chain, chord, group
 from celery.exceptions import TimeoutError
 from celery.result import AsyncResult, GroupResult
+
 from .conftest import flaky
 from .tasks import add, add_replaced, add_to_all, collect_ids, ids, redis_echo
 

--- a/t/integration/test_tasks.py
+++ b/t/integration/test_tasks.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, unicode_literals
+
 from celery import group
+
 from .conftest import flaky
 from .tasks import print_unicode, retry_once, sleeping
 

--- a/t/unit/app/test_amqp.py
+++ b/t/unit/app/test_amqp.py
@@ -1,8 +1,11 @@
 from __future__ import absolute_import, unicode_literals
-import pytest
+
 from datetime import datetime, timedelta
+
+import pytest
 from case import Mock
 from kombu import Exchange, Queue
+
 from celery import uuid
 from celery.app.amqp import Queues, utf8dict
 from celery.five import keys

--- a/t/unit/app/test_annotations.py
+++ b/t/unit/app/test_annotations.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, unicode_literals
+
 from celery.app.annotations import MapAnnotation, prepare
 from celery.utils.imports import qualname
 

--- a/t/unit/app/test_app.py
+++ b/t/unit/app/test_app.py
@@ -1,21 +1,19 @@
 from __future__ import absolute_import, unicode_literals
 
-from datetime import datetime, timedelta
 import gc
 import itertools
 import os
-import pytest
-
 from copy import deepcopy
-from pickle import loads, dumps
+from datetime import datetime, timedelta
+from pickle import dumps, loads
 
+import pytest
 from case import ContextMock, Mock, mock, patch
 from vine import promise
 
-from celery import Celery
-from celery import shared_task, current_app
+from celery import Celery, _state
 from celery import app as _app
-from celery import _state
+from celery import current_app, shared_task
 from celery.app import base as _appbase
 from celery.app import defaults
 from celery.exceptions import ImproperlyConfigured
@@ -23,9 +21,9 @@ from celery.five import items, keys
 from celery.loaders.base import unconfigured
 from celery.platforms import pyimplementation
 from celery.utils.collections import DictAttribute
-from celery.utils.serialization import pickle
-from celery.utils.time import timezone, to_utc, localize
 from celery.utils.objects import Bunch
+from celery.utils.serialization import pickle
+from celery.utils.time import localize, timezone, to_utc
 
 THIS_IS_A_KEY = 'this is a value'
 

--- a/t/unit/app/test_backends.py
+++ b/t/unit/app/test_backends.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import, unicode_literals
+
 import pytest
 from case import patch
+
 from celery.app import backends
 from celery.backends.amqp import AMQPBackend
 from celery.backends.cache import CacheBackend

--- a/t/unit/app/test_beat.py
+++ b/t/unit/app/test_beat.py
@@ -1,14 +1,16 @@
 from __future__ import absolute_import, unicode_literals
+
 import errno
-import pytest
 from datetime import datetime, timedelta
 from pickle import dumps, loads
+
+import pytest
 from case import Mock, call, patch, skip
-from celery import beat
-from celery import uuid
+
+from celery import beat, uuid
 from celery.beat import event_t
 from celery.five import keys, string_t
-from celery.schedules import schedule, crontab
+from celery.schedules import crontab, schedule
 from celery.utils.objects import Bunch
 
 
@@ -310,7 +312,7 @@ class test_Scheduler:
         scheduler = mScheduler(app=self.app)
         nums = [600, 300, 650, 120, 250, 36]
         s = dict(('test_ticks%s' % i,
-                 {'schedule': mocked_schedule(False, j)})
+                  {'schedule': mocked_schedule(False, j)})
                  for i, j in enumerate(nums))
         scheduler.update_from_dict(s)
         assert scheduler.tick() == min(nums) - 0.010

--- a/t/unit/app/test_builtins.py
+++ b/t/unit/app/test_builtins.py
@@ -1,7 +1,9 @@
 from __future__ import absolute_import, unicode_literals
+
 import pytest
 from case import ContextMock, Mock, patch
-from celery import group, chord
+
+from celery import chord, group
 from celery.app import builtins
 from celery.five import range
 from celery.utils.functional import pass1

--- a/t/unit/app/test_celery.py
+++ b/t/unit/app/test_celery.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import, unicode_literals
-import celery
+
 import pytest
+
+import celery
 
 
 def test_version():

--- a/t/unit/app/test_control.py
+++ b/t/unit/app/test_control.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import, unicode_literals
+
 import pytest
 from case import Mock
+
 from celery import uuid
 from celery.app import control
 from celery.exceptions import DuplicateNodenameWarning

--- a/t/unit/app/test_defaults.py
+++ b/t/unit/app/test_defaults.py
@@ -1,11 +1,13 @@
 from __future__ import absolute_import, unicode_literals
+
 import sys
 from importlib import import_module
+
 from case import mock
-from celery.app.defaults import (
-    _OLD_DEFAULTS, _OLD_SETTING_KEYS, _TO_NEW_KEY, _TO_OLD_KEY,
-    DEFAULTS, NAMESPACES, SETTING_KEYS
-)
+
+from celery.app.defaults import (_OLD_DEFAULTS, _OLD_SETTING_KEYS,
+                                 _TO_NEW_KEY, _TO_OLD_KEY, DEFAULTS,
+                                 NAMESPACES, SETTING_KEYS)
 from celery.five import values
 
 

--- a/t/unit/app/test_exceptions.py
+++ b/t/unit/app/test_exceptions.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import, unicode_literals
+
 import pickle
 from datetime import datetime
+
 from celery.exceptions import Reject, Retry
 
 

--- a/t/unit/app/test_loaders.py
+++ b/t/unit/app/test_loaders.py
@@ -1,17 +1,16 @@
 from __future__ import absolute_import, unicode_literals
 
 import os
-import pytest
 import sys
 import warnings
 
+import pytest
 from case import Mock, mock, patch
 
 from celery import loaders
 from celery.exceptions import NotConfigured
 from celery.five import bytes_if_py2
-from celery.loaders import base
-from celery.loaders import default
+from celery.loaders import base, default
 from celery.loaders.app import AppLoader
 from celery.utils.imports import NotAPackage
 

--- a/t/unit/app/test_log.py
+++ b/t/unit/app/test_log.py
@@ -1,30 +1,22 @@
 from __future__ import absolute_import, unicode_literals
 
 import logging
-import pytest
 import sys
-
 from collections import defaultdict
 from io import StringIO
 from tempfile import mktemp
 
+import pytest
 from case import Mock, mock, patch, skip
 from case.utils import get_logger_handlers
 
-from celery import signals
-from celery import uuid
+from celery import signals, uuid
 from celery.app.log import TaskFormatter
 from celery.five import python_2_unicode_compatible
-from celery.utils.log import LoggingProxy
-from celery.utils.log import (
-    get_logger,
-    ColorFormatter,
-    logger as base_logger,
-    get_task_logger,
-    task_logger,
-    in_sighandler,
-    logger_isa,
-)
+from celery.utils.log import (ColorFormatter, LoggingProxy, get_logger,
+                              get_task_logger, in_sighandler)
+from celery.utils.log import logger as base_logger
+from celery.utils.log import logger_isa, task_logger
 
 
 class test_TaskFormatter:

--- a/t/unit/app/test_registry.py
+++ b/t/unit/app/test_registry.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, unicode_literals
+
 import pytest
+
 from celery.app.registry import _unpickle_task, _unpickle_task_v2
 from celery.exceptions import InvalidTaskError
 

--- a/t/unit/app/test_routes.py
+++ b/t/unit/app/test_routes.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
 import pytest
-
 from case import ANY, Mock
 from kombu import Exchange, Queue
 from kombu.utils.functional import maybe_evaluate

--- a/t/unit/app/test_schedules.py
+++ b/t/unit/app/test_schedules.py
@@ -1,18 +1,16 @@
 from __future__ import absolute_import, unicode_literals
 
-import pytest
 import time
-
 from contextlib import contextmanager
 from datetime import datetime, timedelta
 from pickle import dumps, loads
 
+import pytest
 from case import Case, Mock, skip
 
 from celery.five import items
-from celery.schedules import (
-    ParseException, crontab, crontab_parser, schedule, solar,
-)
+from celery.schedules import (ParseException, crontab, crontab_parser,
+                              schedule, solar)
 
 assertions = Case('__init__')
 

--- a/t/unit/app/test_utils.py
+++ b/t/unit/app/test_utils.py
@@ -1,7 +1,10 @@
 from __future__ import absolute_import, unicode_literals
+
 from collections import Mapping, MutableMapping
+
 from case import Mock
-from celery.app.utils import Settings, filter_hidden_settings, bugreport
+
+from celery.app.utils import Settings, bugreport, filter_hidden_settings
 
 
 class test_Settings:

--- a/t/unit/apps/test_multi.py
+++ b/t/unit/apps/test_multi.py
@@ -1,12 +1,14 @@
 from __future__ import absolute_import, unicode_literals
+
 import errno
-import pytest
 import signal
 import sys
+
+import pytest
 from case import Mock, call, patch, skip
-from celery.apps.multi import (
-    Cluster, MultiParser, NamespacedOptionParser, Node, format_opt,
-)
+
+from celery.apps.multi import (Cluster, MultiParser, NamespacedOptionParser,
+                               Node, format_opt)
 
 
 class test_functions:
@@ -102,7 +104,7 @@ class test_multi_args:
         assert expand('%h') == '*P*jerry@*S*'
         assert expand('%n') == '*P*jerry'
         nodes2 = list(multi_args(p, cmd='COMMAND', append='',
-                      prefix='*P*', suffix='*S*'))
+                                 prefix='*P*', suffix='*S*'))
         assert nodes2[0].argv[-1] == '-- .disable_rate_limits=1'
 
         p2 = NamespacedOptionParser(['10', '-c:1', '5'])

--- a/t/unit/backends/test_amqp.py
+++ b/t/unit/backends/test_amqp.py
@@ -1,17 +1,15 @@
 from __future__ import absolute_import, unicode_literals
 
 import pickle
-import pytest
-
 from contextlib import contextmanager
 from datetime import timedelta
 from pickle import dumps, loads
 
-from case import Mock, mock
+import pytest
 from billiard.einfo import ExceptionInfo
+from case import Mock, mock
 
-from celery import states
-from celery import uuid
+from celery import states, uuid
 from celery.backends.amqp import AMQPBackend
 from celery.five import Empty, Queue, range
 from celery.result import AsyncResult

--- a/t/unit/backends/test_base.py
+++ b/t/unit/backends/test_base.py
@@ -1,30 +1,24 @@
 from __future__ import absolute_import, unicode_literals
 
-import pytest
 import sys
 import types
-
 from contextlib import contextmanager
 
+import pytest
 from case import ANY, Mock, call, patch, skip
 
-from celery import states
-from celery import chord, group, uuid
-from celery.backends.base import (
-    BaseBackend,
-    KeyValueStoreBackend,
-    DisabledBackend,
-    _nulldict,
-)
+from celery import chord, group, states, uuid
+from celery.backends.base import (BaseBackend, DisabledBackend,
+                                  KeyValueStoreBackend, _nulldict)
 from celery.exceptions import ChordError, TimeoutError
-from celery.five import items, bytes_if_py2, range
+from celery.five import bytes_if_py2, items, range
 from celery.result import result_from_tuple
 from celery.utils import serialization
 from celery.utils.functional import pass1
-from celery.utils.serialization import subclass_exception
-from celery.utils.serialization import find_pickleable_exception as fnpe
 from celery.utils.serialization import UnpickleableExceptionWrapper
+from celery.utils.serialization import find_pickleable_exception as fnpe
 from celery.utils.serialization import get_pickleable_exception as gpe
+from celery.utils.serialization import subclass_exception
 
 
 class wrapobject(object):

--- a/t/unit/backends/test_cache.py
+++ b/t/unit/backends/test_cache.py
@@ -1,15 +1,17 @@
 from __future__ import absolute_import, unicode_literals
-import pytest
+
 import sys
 import types
 from contextlib import contextmanager
+
+import pytest
 from case import Mock, mock, patch, skip
-from kombu.utils.encoding import str_to_bytes, ensure_bytes
-from celery import states
-from celery import group, signature, uuid
+from kombu.utils.encoding import ensure_bytes, str_to_bytes
+
+from celery import group, signature, states, uuid
 from celery.backends.cache import CacheBackend, DummyClient, backends
 from celery.exceptions import ImproperlyConfigured
-from celery.five import items, bytes_if_py2, string, text_t
+from celery.five import bytes_if_py2, items, string, text_t
 
 PY3 = sys.version_info[0] == 3
 

--- a/t/unit/backends/test_cassandra.py
+++ b/t/unit/backends/test_cassandra.py
@@ -1,8 +1,11 @@
 from __future__ import absolute_import, unicode_literals
-import pytest
-from pickle import loads, dumps
+
 from datetime import datetime
+from pickle import dumps, loads
+
+import pytest
 from case import Mock, mock
+
 from celery import states
 from celery.exceptions import ImproperlyConfigured
 from celery.utils.objects import Bunch

--- a/t/unit/backends/test_consul.py
+++ b/t/unit/backends/test_consul.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, unicode_literals
+
 from case import Mock, skip
+
 from celery.backends.consul import ConsulBackend
 
 

--- a/t/unit/backends/test_couchbase.py
+++ b/t/unit/backends/test_couchbase.py
@@ -1,8 +1,10 @@
 """Tests for the CouchbaseBackend."""
 from __future__ import absolute_import, unicode_literals
+
 import pytest
-from kombu.utils.encoding import str_t
 from case import MagicMock, Mock, patch, sentinel, skip
+from kombu.utils.encoding import str_t
+
 from celery.app import backends
 from celery.backends import couchbase as module
 from celery.backends.couchbase import CouchbaseBackend

--- a/t/unit/backends/test_couchdb.py
+++ b/t/unit/backends/test_couchdb.py
@@ -1,10 +1,13 @@
 from __future__ import absolute_import, unicode_literals
+
 import pytest
 from case import MagicMock, Mock, sentinel, skip
+
 from celery.app import backends
 from celery.backends import couchdb as module
 from celery.backends.couchdb import CouchBackend
 from celery.exceptions import ImproperlyConfigured
+
 try:
     import pycouchdb
 except ImportError:
@@ -30,10 +33,10 @@ class test_CouchBackend:
             module.pycouchdb = prev
 
     def test_get_container_exists(self):
-            self.backend._connection = sentinel._connection
-            connection = self.backend.connection
-            assert connection is sentinel._connection
-            self.Server.assert_not_called()
+        self.backend._connection = sentinel._connection
+        connection = self.backend.connection
+        assert connection is sentinel._connection
+        self.Server.assert_not_called()
 
     def test_get(self):
         """test_get

--- a/t/unit/backends/test_database.py
+++ b/t/unit/backends/test_database.py
@@ -1,14 +1,12 @@
 from __future__ import absolute_import, unicode_literals
 
-import pytest
-
 from datetime import datetime
-from pickle import loads, dumps
+from pickle import dumps, loads
 
+import pytest
 from case import Mock, patch, skip
 
-from celery import states
-from celery import uuid
+from celery import states, uuid
 from celery.exceptions import ImproperlyConfigured
 
 try:

--- a/t/unit/backends/test_dynamodb.py
+++ b/t/unit/backends/test_dynamodb.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
+
 from decimal import Decimal
 
 import pytest
@@ -42,37 +43,37 @@ class test_DynamoDBBackend:
             'celery.backends.dynamodb.DynamoDBBackend._get_or_create_table'
         with patch('boto3.client') as mock_boto_client, \
                 patch(table_creation_path):
-                backend = DynamoDBBackend(
-                    app=self.app,
-                    url='dynamodb://@localhost:8000'
-                )
-                client = backend._get_client()
-                assert backend.client is client
-                mock_boto_client.assert_called_once_with(
-                    'dynamodb',
-                    endpoint_url='http://localhost:8000',
-                    region_name='us-east-1'
-                )
-                assert backend.endpoint_url == 'http://localhost:8000'
+            backend = DynamoDBBackend(
+                app=self.app,
+                url='dynamodb://@localhost:8000'
+            )
+            client = backend._get_client()
+            assert backend.client is client
+            mock_boto_client.assert_called_once_with(
+                'dynamodb',
+                endpoint_url='http://localhost:8000',
+                region_name='us-east-1'
+            )
+            assert backend.endpoint_url == 'http://localhost:8000'
 
     def test_get_client_credentials(self):
         table_creation_path = \
             'celery.backends.dynamodb.DynamoDBBackend._get_or_create_table'
         with patch('boto3.client') as mock_boto_client, \
                 patch(table_creation_path):
-                backend = DynamoDBBackend(
-                    app=self.app,
-                    url='dynamodb://key:secret@test'
-                )
-                client = backend._get_client()
-                assert client is backend.client
-                mock_boto_client.assert_called_once_with(
-                    'dynamodb',
-                    aws_access_key_id='key',
-                    aws_secret_access_key='secret',
-                    region_name='test'
-                )
-                assert backend.aws_region == 'test'
+            backend = DynamoDBBackend(
+                app=self.app,
+                url='dynamodb://key:secret@test'
+            )
+            client = backend._get_client()
+            assert client is backend.client
+            mock_boto_client.assert_called_once_with(
+                'dynamodb',
+                aws_access_key_id='key',
+                aws_secret_access_key='secret',
+                region_name='test'
+            )
+            assert backend.aws_region == 'test'
 
     def test_get_or_create_table_not_exists(self):
         self.backend._client = MagicMock()

--- a/t/unit/backends/test_elasticsearch.py
+++ b/t/unit/backends/test_elasticsearch.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import, unicode_literals
+
 import pytest
 from case import Mock, sentinel, skip
+
 from celery.app import backends
 from celery.backends import elasticsearch as module
 from celery.backends.elasticsearch import ElasticsearchBackend

--- a/t/unit/backends/test_filesystem.py
+++ b/t/unit/backends/test_filesystem.py
@@ -2,13 +2,12 @@
 from __future__ import absolute_import, unicode_literals
 
 import os
-import pytest
 import tempfile
 
+import pytest
 from case import skip
 
-from celery import uuid
-from celery import states
+from celery import states, uuid
 from celery.backends.filesystem import FilesystemBackend
 from celery.exceptions import ImproperlyConfigured
 

--- a/t/unit/backends/test_mongodb.py
+++ b/t/unit/backends/test_mongodb.py
@@ -1,16 +1,13 @@
 from __future__ import absolute_import, unicode_literals
 
-import pytest
-
 import datetime
+from pickle import dumps, loads
 
-from pickle import loads, dumps
-
+import pytest
 from case import ANY, MagicMock, Mock, mock, patch, sentinel, skip
 from kombu.exceptions import EncodeError
 
-from celery import uuid
-from celery import states
+from celery import states, uuid
 from celery.backends.mongodb import InvalidDocument, MongoBackend
 from celery.exceptions import ImproperlyConfigured
 

--- a/t/unit/backends/test_redis.py
+++ b/t/unit/backends/test_redis.py
@@ -1,17 +1,17 @@
 from __future__ import absolute_import, unicode_literals
-import pytest
+
 import ssl
-from datetime import timedelta
 from contextlib import contextmanager
-from pickle import loads, dumps
-from case import ANY, ContextMock, Mock, mock, call, patch, skip
-from celery import signature
-from celery import states
-from celery import uuid
+from datetime import timedelta
+from pickle import dumps, loads
+
+import pytest
+from case import ANY, ContextMock, Mock, call, mock, patch, skip
+
+from celery import signature, states, uuid
 from celery.canvas import Signature
-from celery.exceptions import (
-    ChordError, CPendingDeprecationWarning, ImproperlyConfigured,
-)
+from celery.exceptions import (ChordError, CPendingDeprecationWarning,
+                               ImproperlyConfigured)
 from celery.utils.collections import AttributeDict
 
 

--- a/t/unit/backends/test_riak.py
+++ b/t/unit/backends/test_riak.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
+
 import pytest
 from case import MagicMock, Mock, patch, sentinel, skip
+
 from celery.backends import riak as module
 from celery.backends.riak import RiakBackend
 from celery.exceptions import ImproperlyConfigured

--- a/t/unit/backends/test_rpc.py
+++ b/t/unit/backends/test_rpc.py
@@ -1,9 +1,11 @@
 from __future__ import absolute_import, unicode_literals
+
 import pytest
 from case import Mock, patch
+
 from celery import chord, group
-from celery.backends.rpc import RPCBackend
 from celery._state import _task_stack
+from celery.backends.rpc import RPCBackend
 
 
 class test_RPCBackend:

--- a/t/unit/bin/celery.py
+++ b/t/unit/bin/celery.py
@@ -1,2 +1,3 @@
 from __future__ import absolute_import, unicode_literals
+
 # here for a test

--- a/t/unit/bin/test_amqp.py
+++ b/t/unit/bin/test_amqp.py
@@ -1,14 +1,10 @@
 from __future__ import absolute_import, unicode_literals
+
 import pytest
 from case import Mock, patch
+
+from celery.bin.amqp import AMQPAdmin, AMQShell, amqp, dump_message, main
 from celery.five import WhateverIO
-from celery.bin.amqp import (
-    AMQPAdmin,
-    AMQShell,
-    dump_message,
-    amqp,
-    main,
-)
 
 
 class test_AMQShell:

--- a/t/unit/bin/test_base.py
+++ b/t/unit/bin/test_base.py
@@ -1,13 +1,12 @@
 from __future__ import absolute_import, unicode_literals
+
 import os
+
 import pytest
 from case import Mock, mock, patch
+
+from celery.bin.base import Command, Extensions, Option
 from celery.five import bytes_if_py2
-from celery.bin.base import (
-    Command,
-    Option,
-    Extensions,
-)
 
 
 class MyApp(object):

--- a/t/unit/bin/test_beat.py
+++ b/t/unit/bin/test_beat.py
@@ -1,12 +1,14 @@
 from __future__ import absolute_import, unicode_literals
+
 import logging
-import pytest
 import sys
+
+import pytest
 from case import Mock, mock, patch
-from celery import beat
-from celery import platforms
-from celery.bin import beat as beat_bin
+
+from celery import beat, platforms
 from celery.apps import beat as beatapp
+from celery.bin import beat as beat_bin
 
 
 def MockBeat(*args, **kwargs):

--- a/t/unit/bin/test_call.py
+++ b/t/unit/bin/test_call.py
@@ -1,10 +1,13 @@
 from __future__ import absolute_import, unicode_literals
-import pytest
+
 from datetime import datetime
+
+import pytest
 from case import patch
 from kombu.utils.json import dumps
-from celery.five import WhateverIO
+
 from celery.bin.call import call
+from celery.five import WhateverIO
 
 
 class test_call:

--- a/t/unit/bin/test_celery.py
+++ b/t/unit/bin/test_celery.py
@@ -1,21 +1,19 @@
 from __future__ import absolute_import, unicode_literals
-import pytest
+
 import sys
+
+import pytest
 from case import Mock, patch
+
 from celery import __main__
-from celery.five import WhateverIO
-from celery.platforms import EX_FAILURE, EX_USAGE, EX_OK
-from celery.bin.base import Error
 from celery.bin import celery as mod
-from celery.bin.celery import (
-    Command,
-    help,
-    report,
-    CeleryCommand,
-    determine_exit_status,
-    multi,
-    main as mainfun,
-)
+from celery.bin.base import Error
+from celery.bin.celery import (CeleryCommand, Command, determine_exit_status,
+                               help)
+from celery.bin.celery import main as mainfun
+from celery.bin.celery import multi, report
+from celery.five import WhateverIO
+from celery.platforms import EX_FAILURE, EX_OK, EX_USAGE
 
 
 class test__main__:

--- a/t/unit/bin/test_celeryd_detach.py
+++ b/t/unit/bin/test_celeryd_detach.py
@@ -1,13 +1,10 @@
 from __future__ import absolute_import, unicode_literals
+
 import pytest
 from case import Mock, mock, patch
-from celery.platforms import IS_WINDOWS
-from celery.bin.celeryd_detach import (
-    detach,
-    detached_celeryd,
-    main,
-)
 
+from celery.bin.celeryd_detach import detach, detached_celeryd, main
+from celery.platforms import IS_WINDOWS
 
 if not IS_WINDOWS:
     class test_detached:

--- a/t/unit/bin/test_celeryevdump.py
+++ b/t/unit/bin/test_celeryevdump.py
@@ -1,12 +1,11 @@
 from __future__ import absolute_import, unicode_literals
+
 from time import time
+
 from case import Mock, patch
+
+from celery.events.dumper import Dumper, evdump, humanize_type
 from celery.five import WhateverIO
-from celery.events.dumper import (
-    humanize_type,
-    Dumper,
-    evdump,
-)
 
 
 class test_Dumper:

--- a/t/unit/bin/test_control.py
+++ b/t/unit/bin/test_control.py
@@ -1,9 +1,11 @@
 from __future__ import absolute_import, unicode_literals
+
 import pytest
 from case import Mock, patch
-from celery.five import WhateverIO
+
 from celery.bin.base import Error
-from celery.bin.control import _RemoteControl, inspect, control, status
+from celery.bin.control import _RemoteControl, control, inspect, status
+from celery.five import WhateverIO
 
 
 class test_RemoteControl:

--- a/t/unit/bin/test_events.py
+++ b/t/unit/bin/test_events.py
@@ -1,7 +1,10 @@
 from __future__ import absolute_import, unicode_literals
+
 import importlib
 from functools import wraps
+
 from case import patch, skip
+
 from celery.bin import events
 
 
@@ -31,6 +34,8 @@ class MockCommand(object):
 
 def proctitle(prog, info=None):
     proctitle.last = (prog, info)
+
+
 proctitle.last = ()  # noqa: E305
 
 

--- a/t/unit/bin/test_list.py
+++ b/t/unit/bin/test_list.py
@@ -1,7 +1,9 @@
 from __future__ import absolute_import, unicode_literals
+
 import pytest
 from case import Mock
 from kombu.five import WhateverIO
+
 from celery.bin.base import Error
 from celery.bin.list import list_
 

--- a/t/unit/bin/test_migrate.py
+++ b/t/unit/bin/test_migrate.py
@@ -1,8 +1,10 @@
 from __future__ import absolute_import, unicode_literals
+
 import pytest
 from case import Mock, patch
-from celery.five import WhateverIO
+
 from celery.bin.migrate import migrate
+from celery.five import WhateverIO
 
 
 class test_migrate:

--- a/t/unit/bin/test_multi.py
+++ b/t/unit/bin/test_multi.py
@@ -1,9 +1,14 @@
 from __future__ import absolute_import, unicode_literals
-import pytest
+
 import signal
 import sys
+
+import pytest
 from case import Mock, patch
-from celery.bin.multi import main, MultiTool, __doc__ as doc
+
+from celery.bin.multi import MultiTool
+from celery.bin.multi import __doc__ as doc
+from celery.bin.multi import main
 from celery.five import WhateverIO
 
 

--- a/t/unit/bin/test_purge.py
+++ b/t/unit/bin/test_purge.py
@@ -1,7 +1,9 @@
 from __future__ import absolute_import, unicode_literals
+
 from case import Mock
-from celery.five import WhateverIO
+
 from celery.bin.purge import purge
+from celery.five import WhateverIO
 
 
 class test_purge:

--- a/t/unit/bin/test_result.py
+++ b/t/unit/bin/test_result.py
@@ -1,7 +1,9 @@
 from __future__ import absolute_import, unicode_literals
+
 from case import patch
-from celery.five import WhateverIO
+
 from celery.bin.result import result
+from celery.five import WhateverIO
 
 
 class test_result:

--- a/t/unit/bin/test_worker.py
+++ b/t/unit/bin/test_worker.py
@@ -2,21 +2,20 @@ from __future__ import absolute_import, unicode_literals
 
 import logging
 import os
-import pytest
 import sys
 
+import pytest
 from billiard.process import current_process
 from case import Mock, mock, patch, skip
 from kombu import Exchange, Queue
 
-from celery import platforms
-from celery import signals
+from celery import platforms, signals
 from celery.app import trace
 from celery.apps import worker as cd
-from celery.bin.worker import worker, main as worker_main
-from celery.exceptions import (
-    ImproperlyConfigured, WorkerShutdown, WorkerTerminate,
-)
+from celery.bin.worker import main as worker_main
+from celery.bin.worker import worker
+from celery.exceptions import (ImproperlyConfigured, WorkerShutdown,
+                               WorkerTerminate)
 from celery.platforms import EX_FAILURE, EX_OK
 from celery.worker import state
 
@@ -407,7 +406,7 @@ class test_funs:
         cmd = worker()
         cmd.app = self.app
         opts, args = cmd.parse_options('worker', ['--concurrency=512',
-                                       '--heartbeat-interval=10'])
+                                                  '--heartbeat-interval=10'])
         assert opts['concurrency'] == 512
         assert opts['heartbeat_interval'] == 10
 

--- a/t/unit/compat_modules/test_compat.py
+++ b/t/unit/compat_modules/test_compat.py
@@ -1,12 +1,12 @@
 from __future__ import absolute_import, unicode_literals
-import pytest
+
 from datetime import timedelta
+
+import pytest
+
 from celery.five import bytes_if_py2
 from celery.schedules import schedule
-from celery.task import (
-    periodic_task,
-    PeriodicTask
-)
+from celery.task import PeriodicTask, periodic_task
 
 
 class test_periodic_tasks:

--- a/t/unit/compat_modules/test_compat_utils.py
+++ b/t/unit/compat_modules/test_compat_utils.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import, unicode_literals
-import celery
+
 import pytest
+
+import celery
 from celery.app.task import Task as ModernTask
 from celery.task.base import Task as CompatTask
 

--- a/t/unit/compat_modules/test_decorators.py
+++ b/t/unit/compat_modules/test_decorators.py
@@ -1,6 +1,9 @@
 from __future__ import absolute_import, unicode_literals
-import pytest
+
 import warnings
+
+import pytest
+
 from celery.task import base
 
 

--- a/t/unit/compat_modules/test_messaging.py
+++ b/t/unit/compat_modules/test_messaging.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, unicode_literals
+
 import pytest
+
 from celery import messaging
 
 

--- a/t/unit/concurrency/test_concurrency.py
+++ b/t/unit/concurrency/test_concurrency.py
@@ -1,9 +1,12 @@
 from __future__ import absolute_import, unicode_literals
+
 import os
-import pytest
 from itertools import count
+
+import pytest
 from case import Mock, patch
-from celery.concurrency.base import apply_target, BasePool
+
+from celery.concurrency.base import BasePool, apply_target
 from celery.exceptions import WorkerShutdown, WorkerTerminate
 
 

--- a/t/unit/concurrency/test_eventlet.py
+++ b/t/unit/concurrency/test_eventlet.py
@@ -1,12 +1,11 @@
 from __future__ import absolute_import, unicode_literals
-import pytest
+
 import sys
+
+import pytest
 from case import Mock, patch, skip
-from celery.concurrency.eventlet import (
-    apply_target,
-    Timer,
-    TaskPool,
-)
+
+from celery.concurrency.eventlet import TaskPool, Timer, apply_target
 
 eventlet_modules = (
     'eventlet',

--- a/t/unit/concurrency/test_gevent.py
+++ b/t/unit/concurrency/test_gevent.py
@@ -1,10 +1,8 @@
 from __future__ import absolute_import, unicode_literals
+
 from case import Mock, skip
-from celery.concurrency.gevent import (
-    Timer,
-    TaskPool,
-    apply_timeout,
-)
+
+from celery.concurrency.gevent import TaskPool, Timer, apply_timeout
 
 gevent_modules = (
     'gevent',

--- a/t/unit/concurrency/test_pool.py
+++ b/t/unit/concurrency/test_pool.py
@@ -1,8 +1,10 @@
 from __future__ import absolute_import, unicode_literals
-import time
+
 import itertools
-from case import skip
+import time
+
 from billiard.einfo import ExceptionInfo
+from case import skip
 
 
 def do_something(i):

--- a/t/unit/concurrency/test_prefork.py
+++ b/t/unit/concurrency/test_prefork.py
@@ -2,11 +2,10 @@ from __future__ import absolute_import, unicode_literals
 
 import errno
 import os
-import pytest
 import socket
-
 from itertools import cycle
 
+import pytest
 from case import Mock, mock, patch, skip
 
 from celery.app.defaults import DEFAULTS

--- a/t/unit/concurrency/test_solo.py
+++ b/t/unit/concurrency/test_solo.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, unicode_literals
+
 import operator
+
 from celery.concurrency import solo
 from celery.utils.functional import noop
 

--- a/t/unit/conftest.py
+++ b/t/unit/conftest.py
@@ -2,13 +2,12 @@ from __future__ import absolute_import, unicode_literals
 
 import logging
 import os
-import pytest
 import sys
 import threading
 import warnings
-
 from importlib import import_module
 
+import pytest
 from case import Mock
 from case.utils import decorator
 from kombu import Queue
@@ -17,13 +16,11 @@ from celery.backends.cache import CacheBackend, DummyClient
 # we have to import the pytest plugin fixtures here,
 # in case user did not do the `python setup.py develop` yet,
 # that installs the pytest plugin into the setuptools registry.
-from celery.contrib.pytest import (
-    celery_app, celery_enable_logging, depends_on_current_app,
-)
-from celery.contrib.testing.app import Trap, TestApp
-from celery.contrib.testing.mocks import (
-    TaskMessage, TaskMessage1, task_message_from_sig,
-)
+from celery.contrib.pytest import (celery_app, celery_enable_logging,
+                                   depends_on_current_app)
+from celery.contrib.testing.app import TestApp, Trap
+from celery.contrib.testing.mocks import (TaskMessage, TaskMessage1,
+                                          task_message_from_sig)
 
 # Tricks flake8 into silencing redefining fixtures warnings.
 __all__ = [

--- a/t/unit/contrib/test_abortable.py
+++ b/t/unit/contrib/test_abortable.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, unicode_literals
-from celery.contrib.abortable import AbortableTask, AbortableAsyncResult
+
+from celery.contrib.abortable import AbortableAsyncResult, AbortableTask
 
 
 class test_AbortableTask:

--- a/t/unit/contrib/test_migrate.py
+++ b/t/unit/contrib/test_migrate.py
@@ -1,33 +1,19 @@
 from __future__ import absolute_import, unicode_literals
 
-import pytest
-
 from contextlib import contextmanager
 
+import pytest
 from amqp import ChannelError
 from case import Mock, mock, patch
-
-from kombu import Connection, Producer, Queue, Exchange
-
+from kombu import Connection, Exchange, Producer, Queue
 from kombu.transport.virtual import QoS
 
-from celery.contrib.migrate import (
-    StopFiltering,
-    State,
-    migrate_task,
-    migrate_tasks,
-    filter_callback,
-    _maybe_queue,
-    filter_status,
-    move_by_taskmap,
-    move_by_idmap,
-    move_task_by_id,
-    start_filter,
-    task_id_in,
-    task_id_eq,
-    expand_dest,
-    move,
-)
+from celery.contrib.migrate import (State, StopFiltering, _maybe_queue,
+                                    expand_dest, filter_callback,
+                                    filter_status, migrate_task,
+                                    migrate_tasks, move, move_by_idmap,
+                                    move_by_taskmap, move_task_by_id,
+                                    start_filter, task_id_eq, task_id_in)
 from celery.utils.encoding import bytes_t, ensure_bytes
 
 # hack to ignore error at shutdown

--- a/t/unit/contrib/test_rdb.py
+++ b/t/unit/contrib/test_rdb.py
@@ -1,13 +1,12 @@
 from __future__ import absolute_import, unicode_literals
+
 import errno
 import socket
+
 import pytest
 from case import Mock, patch, skip
-from celery.contrib.rdb import (
-    Rdb,
-    debugger,
-    set_trace,
-)
+
+from celery.contrib.rdb import Rdb, debugger, set_trace
 from celery.five import WhateverIO
 
 

--- a/t/unit/events/test_cursesmon.py
+++ b/t/unit/events/test_cursesmon.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, unicode_literals
+
 from case import skip
 
 

--- a/t/unit/events/test_events.py
+++ b/t/unit/events/test_events.py
@@ -1,7 +1,10 @@
 from __future__ import absolute_import, unicode_literals
-import pytest
+
 import socket
+
+import pytest
 from case import Mock, call
+
 from celery.events import Event
 from celery.events.receiver import CLIENT_CLOCK_SKEW
 

--- a/t/unit/events/test_snapshot.py
+++ b/t/unit/events/test_snapshot.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import, unicode_literals
+
 import pytest
 from case import Mock, mock, patch
+
 from celery.app.events import Events
 from celery.events.snapshot import Polaroid, evcam
 

--- a/t/unit/events/test_state.py
+++ b/t/unit/events/test_state.py
@@ -1,25 +1,17 @@
 from __future__ import absolute_import, unicode_literals
 
 import pickle
-
 from decimal import Decimal
+from itertools import count
 from random import shuffle
 from time import time
-from itertools import count
 
 from case import Mock, patch, skip
 
-from celery import states
-from celery import uuid
+from celery import states, uuid
 from celery.events import Event
-from celery.events.state import (
-    HEARTBEAT_EXPIRE_WINDOW,
-    HEARTBEAT_DRIFT_MAX,
-    State,
-    Worker,
-    Task,
-    heartbeat_expires,
-)
+from celery.events.state import (HEARTBEAT_DRIFT_MAX, HEARTBEAT_EXPIRE_WINDOW,
+                                 State, Task, Worker, heartbeat_expires)
 from celery.five import range
 
 
@@ -161,7 +153,7 @@ class ev_snapshot(replay):
             worker = not i % 2 and 'utest2' or 'utest1'
             type = not i % 2 and 'task2' or 'task1'
             self.events.append(Event('task-received', name=type,
-                               uuid=uuid(), hostname=worker))
+                                     uuid=uuid(), hostname=worker))
 
 
 class test_Worker:

--- a/t/unit/fixups/test_django.py
+++ b/t/unit/fixups/test_django.py
@@ -1,14 +1,12 @@
 from __future__ import absolute_import, unicode_literals
-import pytest
+
 from contextlib import contextmanager
+
+import pytest
 from case import Mock, mock, patch
-from celery.fixups.django import (
-    _maybe_close_fd,
-    fixup,
-    FixupWarning,
-    DjangoFixup,
-    DjangoWorkerFixup,
-)
+
+from celery.fixups.django import (DjangoFixup, DjangoWorkerFixup,
+                                  FixupWarning, _maybe_close_fd, fixup)
 
 
 class FixupCase:
@@ -137,22 +135,22 @@ class test_DjangoWorkerFixup(FixupCase):
     def test_on_worker_process_init(self, patching):
         with self.fixup_context(self.app) as (f, _, _):
             with patch('celery.fixups.django._maybe_close_fd') as mcf:
-                    _all = f._db.connections.all = Mock()
-                    conns = _all.return_value = [
-                        Mock(), Mock(),
-                    ]
-                    conns[0].connection = None
-                    with patch.object(f, 'close_cache'):
-                        with patch.object(f, '_close_database'):
-                            f.on_worker_process_init()
-                            mcf.assert_called_with(conns[1].connection)
-                            f.close_cache.assert_called_with()
-                            f._close_database.assert_called_with()
+                _all = f._db.connections.all = Mock()
+                conns = _all.return_value = [
+                    Mock(), Mock(),
+                ]
+                conns[0].connection = None
+                with patch.object(f, 'close_cache'):
+                    with patch.object(f, '_close_database'):
+                        f.on_worker_process_init()
+                        mcf.assert_called_with(conns[1].connection)
+                        f.close_cache.assert_called_with()
+                        f._close_database.assert_called_with()
 
-                            f.validate_models = Mock(name='validate_models')
-                            patching.setenv('FORKED_BY_MULTIPROCESSING', '1')
-                            f.on_worker_process_init()
-                            f.validate_models.assert_called_with()
+                        f.validate_models = Mock(name='validate_models')
+                        patching.setenv('FORKED_BY_MULTIPROCESSING', '1')
+                        f.on_worker_process_init()
+                        f.validate_models.assert_called_with()
 
     def test_on_task_prerun(self):
         task = Mock()

--- a/t/unit/security/case.py
+++ b/t/unit/security/case.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, unicode_literals
+
 from case import skip
 
 

--- a/t/unit/security/test_certificate.py
+++ b/t/unit/security/test_certificate.py
@@ -1,8 +1,11 @@
 from __future__ import absolute_import, unicode_literals
+
 import pytest
 from case import Mock, mock, patch, skip
+
 from celery.exceptions import SecurityError
 from celery.security.certificate import Certificate, CertStore, FSCertStore
+
 from . import CERT1, CERT2, KEY1
 from .case import SecurityCase
 

--- a/t/unit/security/test_key.py
+++ b/t/unit/security/test_key.py
@@ -1,8 +1,11 @@
 from __future__ import absolute_import, unicode_literals
+
 import pytest
+
 from celery.exceptions import SecurityError
 from celery.five import bytes_if_py2
 from celery.security.key import PrivateKey
+
 from . import CERT1, KEY1, KEY2
 from .case import SecurityCase
 

--- a/t/unit/security/test_security.py
+++ b/t/unit/security/test_security.py
@@ -15,15 +15,13 @@ Generated with:
 from __future__ import absolute_import, unicode_literals
 
 import pytest
-
 from case import Mock, mock, patch
-from kombu.serialization import disable_insecure_serializers
+from kombu.serialization import disable_insecure_serializers, registry
 
 from celery.exceptions import ImproperlyConfigured, SecurityError
 from celery.five import builtins
 from celery.security import disable_untrusted_serializers, setup_security
 from celery.security.utils import reraise_errors
-from kombu.serialization import registry
 
 from .case import SecurityCase
 

--- a/t/unit/security/test_serialization.py
+++ b/t/unit/security/test_serialization.py
@@ -2,15 +2,15 @@ from __future__ import absolute_import, unicode_literals
 
 import base64
 import os
-import pytest
 
+import pytest
 from kombu.serialization import registry
 from kombu.utils.encoding import bytes_to_str
 
 from celery.exceptions import SecurityError
-from celery.security.serialization import SecureSerializer, register_auth
 from celery.security.certificate import Certificate, CertStore
 from celery.security.key import PrivateKey
+from celery.security.serialization import SecureSerializer, register_auth
 
 from . import CERT1, CERT2, KEY1, KEY2
 from .case import SecurityCase

--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -1,23 +1,15 @@
 from __future__ import absolute_import, unicode_literals
+
 import json
+
 import pytest
 from case import MagicMock, Mock
+
 from celery._state import _task_stack
-from celery.canvas import (
-    Signature,
-    chain,
-    _chain,
-    group,
-    chord,
-    signature,
-    xmap,
-    xstarmap,
-    chunks,
-    _maybe_group,
-    maybe_signature,
-    maybe_unroll_group,
-)
-from celery.result import AsyncResult, GroupResult, EagerResult
+from celery.canvas import (Signature, _chain, _maybe_group, chain, chord,
+                           chunks, group, maybe_signature, maybe_unroll_group,
+                           signature, xmap, xstarmap)
+from celery.result import AsyncResult, EagerResult, GroupResult
 
 SIG = Signature({
     'task': 'TASK',

--- a/t/unit/tasks/test_chord.py
+++ b/t/unit/tasks/test_chord.py
@@ -1,13 +1,14 @@
 from __future__ import absolute_import, unicode_literals
-import pytest
+
 from contextlib import contextmanager
+
+import pytest
 from case import Mock
-from celery import group, uuid
-from celery import canvas
-from celery import result
+
+from celery import canvas, group, result, uuid
 from celery.exceptions import ChordError, Retry
 from celery.five import range
-from celery.result import AsyncResult, GroupResult, EagerResult
+from celery.result import AsyncResult, EagerResult, GroupResult
 
 
 def passthru(x):

--- a/t/unit/tasks/test_context.py
+++ b/t/unit/tasks/test_context.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-'
 from __future__ import absolute_import, unicode_literals
+
 from celery.app.task import Context
 
 

--- a/t/unit/tasks/test_result.py
+++ b/t/unit/tasks/test_result.py
@@ -1,28 +1,19 @@
 from __future__ import absolute_import, unicode_literals
 
-import pytest
 import traceback
-
 from contextlib import contextmanager
 
+import pytest
 from case import Mock, call, patch, skip
 
-from celery import uuid
-from celery import states
+from celery import states, uuid
 from celery.backends.base import SyncBackendMixin
-from celery.exceptions import (
-    CPendingDeprecationWarning, ImproperlyConfigured,
-    IncompleteStream, TimeoutError,
-)
+from celery.exceptions import (CPendingDeprecationWarning,
+                               ImproperlyConfigured, IncompleteStream,
+                               TimeoutError)
 from celery.five import range
-from celery.result import (
-    AsyncResult,
-    EagerResult,
-    ResultSet,
-    GroupResult,
-    result_from_tuple,
-    assert_will_not_block,
-)
+from celery.result import (AsyncResult, EagerResult, GroupResult, ResultSet,
+                           assert_will_not_block, result_from_tuple)
 from celery.utils.serialization import pickle
 
 PYTRACEBACK = """\
@@ -543,17 +534,17 @@ class MockAsyncResultSuccess(AsyncResult):
 
 
 class SimpleBackend(SyncBackendMixin):
-        ids = []
+    ids = []
 
-        def __init__(self, ids=[]):
-            self.ids = ids
+    def __init__(self, ids=[]):
+        self.ids = ids
 
-        def _ensure_not_eager(self):
-            pass
+    def _ensure_not_eager(self):
+        pass
 
-        def get_many(self, *args, **kwargs):
-            return ((id, {'result': i, 'status': states.SUCCESS})
-                    for i, id in enumerate(self.ids))
+    def get_many(self, *args, **kwargs):
+        return ((id, {'result': i, 'status': states.SUCCESS})
+                for i, id in enumerate(self.ids))
 
 
 class test_GroupResult:

--- a/t/unit/tasks/test_states.py
+++ b/t/unit/tasks/test_states.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, unicode_literals
+
 import pytest
+
 from celery import states
 
 

--- a/t/unit/tasks/test_tasks.py
+++ b/t/unit/tasks/test_tasks.py
@@ -1,10 +1,9 @@
 from __future__ import absolute_import, unicode_literals
 
-import pytest
 import socket
-
 from datetime import datetime, timedelta
 
+import pytest
 from case import ContextMock, MagicMock, Mock, patch
 from kombu import Queue
 

--- a/t/unit/tasks/test_trace.py
+++ b/t/unit/tasks/test_trace.py
@@ -1,26 +1,18 @@
 from __future__ import absolute_import, unicode_literals
+
 import pytest
 from case import Mock, patch
 from kombu.exceptions import EncodeError
-from celery import group, uuid
-from celery import signals
-from celery import states
-from celery.exceptions import Ignore, Retry, Reject
-from celery.app.trace import (
-    TraceInfo,
-    build_tracer,
-    get_log_policy,
-    log_policy_reject,
-    log_policy_ignore,
-    log_policy_internal,
-    log_policy_expected,
-    log_policy_unexpected,
-    trace_task,
-    _trace_task_ret,
-    _fast_trace_task,
-    setup_worker_optimizations,
-    reset_worker_optimizations,
-)
+
+from celery import group, signals, states, uuid
+from celery.app.trace import (TraceInfo, _fast_trace_task, _trace_task_ret,
+                              build_tracer, get_log_policy,
+                              log_policy_expected, log_policy_ignore,
+                              log_policy_internal, log_policy_reject,
+                              log_policy_unexpected,
+                              reset_worker_optimizations,
+                              setup_worker_optimizations, trace_task)
+from celery.exceptions import Ignore, Reject, Retry
 
 
 def trace(app, task, args=(), kwargs={},

--- a/t/unit/utils/test_collections.py
+++ b/t/unit/utils/test_collections.py
@@ -1,24 +1,18 @@
 from __future__ import absolute_import, unicode_literals
 
 import pickle
-import pytest
-
 from collections import Mapping
 from itertools import count
 from time import time
 
-from case import skip
+import pytest
 from billiard.einfo import ExceptionInfo
+from case import skip
 
-from celery.utils.collections import (
-    AttributeDict,
-    BufferMap,
-    ConfigurationView,
-    DictAttribute,
-    LimitedSet,
-    Messagebuffer,
-)
 from celery.five import items
+from celery.utils.collections import (AttributeDict, BufferMap,
+                                      ConfigurationView, DictAttribute,
+                                      LimitedSet, Messagebuffer)
 from celery.utils.objects import Bunch
 
 

--- a/t/unit/utils/test_debug.py
+++ b/t/unit/utils/test_debug.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import, unicode_literals
+
 import pytest
 from case import Mock
+
 from celery.utils import debug
 
 

--- a/t/unit/utils/test_deprecated.py
+++ b/t/unit/utils/test_deprecated.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import, unicode_literals
+
 import pytest
 from case import patch
+
 from celery.utils import deprecated
 
 

--- a/t/unit/utils/test_dispatcher.py
+++ b/t/unit/utils/test_dispatcher.py
@@ -1,9 +1,10 @@
 from __future__ import absolute_import, unicode_literals
+
 import gc
 import sys
 import time
-from celery.utils.dispatch import Signal
 
+from celery.utils.dispatch import Signal
 
 if sys.platform.startswith('java'):
 

--- a/t/unit/utils/test_encoding.py
+++ b/t/unit/utils/test_encoding.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, unicode_literals
+
 from celery.utils import encoding
 
 

--- a/t/unit/utils/test_functional.py
+++ b/t/unit/utils/test_functional.py
@@ -1,22 +1,15 @@
 from __future__ import absolute_import, unicode_literals
+
 import pytest
-from kombu.utils.functional import lazy
 from case import skip
-from celery.five import range, nextfun
-from celery.utils.functional import (
-    DummyContext,
-    fun_accepts_kwargs,
-    fun_takes_argument,
-    head_from_fun,
-    firstmethod,
-    first,
-    maybe_list,
-    mlazy,
-    padlist,
-    regen,
-    seq_concat_seq,
-    seq_concat_item,
-)
+from kombu.utils.functional import lazy
+
+from celery.five import nextfun, range
+from celery.utils.functional import (DummyContext, first, firstmethod,
+                                     fun_accepts_kwargs, fun_takes_argument,
+                                     head_from_fun, maybe_list, mlazy,
+                                     padlist, regen, seq_concat_item,
+                                     seq_concat_seq)
 
 
 def test_DummyContext():

--- a/t/unit/utils/test_graph.py
+++ b/t/unit/utils/test_graph.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, unicode_literals
+
 from case import Mock
+
 from celery.five import WhateverIO, items
 from celery.utils.graph import DependencyGraph
 

--- a/t/unit/utils/test_imports.py
+++ b/t/unit/utils/test_imports.py
@@ -1,15 +1,11 @@
 from __future__ import absolute_import, unicode_literals
+
 import pytest
 from case import Mock
+
 from celery.five import bytes_if_py2
-from celery.utils.imports import (
-    NotAPackage,
-    qualname,
-    gen_task_name,
-    reload_from_cwd,
-    module_file,
-    find_module,
-)
+from celery.utils.imports import (NotAPackage, find_module, gen_task_name,
+                                  module_file, qualname, reload_from_cwd)
 
 
 def test_find_module():

--- a/t/unit/utils/test_local.py
+++ b/t/unit/utils/test_local.py
@@ -1,14 +1,12 @@
 from __future__ import absolute_import, unicode_literals
-import pytest
+
 import sys
+
+import pytest
 from case import Mock, skip
-from celery.five import python_2_unicode_compatible, string, long_t
-from celery.local import (
-    Proxy,
-    PromiseProxy,
-    maybe_evaluate,
-    try_import,
-)
+
+from celery.five import long_t, python_2_unicode_compatible, string
+from celery.local import PromiseProxy, Proxy, maybe_evaluate, try_import
 
 PY3 = sys.version_info[0] == 3
 

--- a/t/unit/utils/test_nodenames.py
+++ b/t/unit/utils/test_nodenames.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, unicode_literals
+
 from kombu import Queue
+
 from celery.utils.nodenames import worker_direct
 
 

--- a/t/unit/utils/test_objects.py
+++ b/t/unit/utils/test_objects.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, unicode_literals
+
 from celery.utils.objects import Bunch
 
 

--- a/t/unit/utils/test_pickle.py
+++ b/t/unit/utils/test_pickle.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, unicode_literals
+
 from celery.utils.serialization import pickle
 
 

--- a/t/unit/utils/test_platforms.py
+++ b/t/unit/utils/test_platforms.py
@@ -2,41 +2,24 @@ from __future__ import absolute_import, unicode_literals
 
 import errno
 import os
-import pytest
-import sys
 import signal
+import sys
 import tempfile
 
+import pytest
 from case import Mock, call, mock, patch, skip
 
-from celery import _find_option_with_arg
-from celery import platforms
+from celery import _find_option_with_arg, platforms
 from celery.exceptions import SecurityError
 from celery.five import WhateverIO
-from celery.platforms import (
-    get_fdmax,
-    ignore_errno,
-    check_privileges,
-    set_process_title,
-    set_mp_process_title,
-    signals,
-    maybe_drop_privileges,
-    setuid,
-    setgid,
-    initgroups,
-    parse_uid,
-    parse_gid,
-    detached,
-    DaemonContext,
-    create_pidlock,
-    Pidfile,
-    LockFailed,
-    setgroups,
-    _setgroups_hack,
-    close_open_fds,
-    fd_by_path,
-    isatty,
-)
+from celery.platforms import (DaemonContext, LockFailed, Pidfile,
+                              _setgroups_hack, check_privileges,
+                              close_open_fds, create_pidlock, detached,
+                              fd_by_path, get_fdmax, ignore_errno, initgroups,
+                              isatty, maybe_drop_privileges, parse_gid,
+                              parse_uid, set_mp_process_title,
+                              set_process_title, setgid, setgroups, setuid,
+                              signals)
 
 try:
     import resource

--- a/t/unit/utils/test_saferepr.py
+++ b/t/unit/utils/test_saferepr.py
@@ -1,14 +1,16 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
-import pytest
+
 import re
 import struct
-from case import skip
 from decimal import Decimal
 from pprint import pprint
-from celery.five import (
-    items, long_t, python_2_unicode_compatible, text_t, values,
-)
+
+import pytest
+from case import skip
+
+from celery.five import (items, long_t, python_2_unicode_compatible, text_t,
+                         values)
 from celery.utils.saferepr import saferepr
 
 D_NUMBERS = {

--- a/t/unit/utils/test_serialization.py
+++ b/t/unit/utils/test_serialization.py
@@ -1,15 +1,15 @@
 from __future__ import absolute_import, unicode_literals
+
+import sys
+from datetime import date, datetime, time, timedelta
+
 import pytest
 import pytz
-import sys
-from datetime import datetime, date, time, timedelta
 from case import Mock, mock
 from kombu import Queue
-from celery.utils.serialization import (
-    UnpickleableExceptionWrapper,
-    get_pickleable_etype,
-    jsonify,
-)
+
+from celery.utils.serialization import (UnpickleableExceptionWrapper,
+                                        get_pickleable_etype, jsonify)
 
 
 class test_AAPickle:

--- a/t/unit/utils/test_sysinfo.py
+++ b/t/unit/utils/test_sysinfo.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import, unicode_literals
+
 from case import skip
-from celery.utils.sysinfo import load_average, df
+
+from celery.utils.sysinfo import df, load_average
 
 
 @skip.unless_symbol('os.getloadavg')

--- a/t/unit/utils/test_term.py
+++ b/t/unit/utils/test_term.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
+
 import pytest
 from case import skip
+
+from celery.five import text_t
 from celery.utils import term
 from celery.utils.term import colored, fg
-from celery.five import text_t
 
 
 @skip.if_win32()

--- a/t/unit/utils/test_text.py
+++ b/t/unit/utils/test_text.py
@@ -1,13 +1,9 @@
 from __future__ import absolute_import, unicode_literals
+
 import pytest
-from celery.utils.text import (
-    abbr,
-    abbrtask,
-    ensure_newlines,
-    indent,
-    pretty,
-    truncate,
-)
+
+from celery.utils.text import (abbr, abbrtask, ensure_newlines, indent,
+                               pretty, truncate)
 
 RANDTEXT = """\
 The quick brown

--- a/t/unit/utils/test_threads.py
+++ b/t/unit/utils/test_threads.py
@@ -1,13 +1,10 @@
 from __future__ import absolute_import, unicode_literals
+
 import pytest
 from case import mock, patch
-from celery.utils.threads import (
-    _LocalStack,
-    _FastLocalStack,
-    LocalManager,
-    Local,
-    bgThread,
-)
+
+from celery.utils.threads import (Local, LocalManager, _FastLocalStack,
+                                  _LocalStack, bgThread)
 
 
 class test_bgThread:

--- a/t/unit/utils/test_time.py
+++ b/t/unit/utils/test_time.py
@@ -1,25 +1,18 @@
 from __future__ import absolute_import, unicode_literals
+
+from datetime import datetime, timedelta, tzinfo
+
 import pytest
 import pytz
-from datetime import datetime, timedelta, tzinfo
-from pytz import AmbiguousTimeError
 from case import Mock
-from celery.utils.time import (
-    delta_resolution,
-    humanize_seconds,
-    maybe_iso8601,
-    maybe_timedelta,
-    timezone,
-    rate,
-    remaining,
-    make_aware,
-    maybe_make_aware,
-    localize,
-    LocalTimezone,
-    ffwd,
-    utcoffset,
-)
+from pytz import AmbiguousTimeError
+
 from celery.utils.iso8601 import parse_iso8601
+from celery.utils.time import (LocalTimezone, delta_resolution, ffwd,
+                               humanize_seconds, localize, make_aware,
+                               maybe_iso8601, maybe_make_aware,
+                               maybe_timedelta, rate, remaining, timezone,
+                               utcoffset)
 
 
 class test_LocalTimezone:

--- a/t/unit/utils/test_timer2.py
+++ b/t/unit/utils/test_timer2.py
@@ -1,7 +1,10 @@
 from __future__ import absolute_import, unicode_literals
+
 import sys
 import time
-from case import Mock, patch, call
+
+from case import Mock, call, patch
+
 import celery.utils.timer2 as timer2
 
 

--- a/t/unit/utils/test_utils.py
+++ b/t/unit/utils/test_utils.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import, unicode_literals
+
 import pytest
-from celery.utils import chunks, cached_property
+
+from celery.utils import cached_property, chunks
 
 
 @pytest.mark.parametrize('items,n,expected', [
@@ -9,8 +11,8 @@ from celery.utils import chunks, cached_property
     (range(10), 2, [[0, 1], [2, 3], [4, 5], [6, 7], [8, 9]]),
 ])
 def test_chunks(items, n, expected):
-        x = chunks(iter(list(items)), n)
-        assert list(x) == expected
+    x = chunks(iter(list(items)), n)
+    assert list(x) == expected
 
 
 def test_cached_property():

--- a/t/unit/worker/test_autoscale.py
+++ b/t/unit/worker/test_autoscale.py
@@ -1,11 +1,13 @@
 from __future__ import absolute_import, unicode_literals
+
 import sys
+
 from case import Mock, mock, patch
+
 from celery.concurrency.base import BasePool
 from celery.five import monotonic
-from celery.worker import state
-from celery.worker import autoscale
 from celery.utils.objects import Bunch
+from celery.worker import autoscale, state
 
 
 class MockPool(BasePool):

--- a/t/unit/worker/test_bootsteps.py
+++ b/t/unit/worker/test_bootsteps.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import, unicode_literals
+
 import pytest
 from case import Mock, patch
+
 from celery import bootsteps
 
 

--- a/t/unit/worker/test_components.py
+++ b/t/unit/worker/test_components.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import, unicode_literals
+
 import pytest
 from case import Mock, patch, skip
+
 from celery.exceptions import ImproperlyConfigured
 from celery.worker.components import Beat, Hub, Pool, Timer
 

--- a/t/unit/worker/test_consumer.py
+++ b/t/unit/worker/test_consumer.py
@@ -1,22 +1,21 @@
 from __future__ import absolute_import, unicode_literals
 
 import errno
-import pytest
 import socket
-
 from collections import deque
 
-from case import ContextMock, Mock, call, patch, skip
+import pytest
 from billiard.exceptions import RestartFreqExceeded
+from case import ContextMock, Mock, call, patch, skip
 
+from celery.utils.collections import LimitedSet
 from celery.worker.consumer.agent import Agent
-from celery.worker.consumer.consumer import (CLOSE, TERMINATE,
-                                             Consumer, dump_body)
+from celery.worker.consumer.consumer import (CLOSE, TERMINATE, Consumer,
+                                             dump_body)
 from celery.worker.consumer.gossip import Gossip
 from celery.worker.consumer.heart import Heart
 from celery.worker.consumer.mingle import Mingle
 from celery.worker.consumer.tasks import Tasks
-from celery.utils.collections import LimitedSet
 
 
 class test_Consumer:

--- a/t/unit/worker/test_control.py
+++ b/t/unit/worker/test_control.py
@@ -1,26 +1,24 @@
 from __future__ import absolute_import, unicode_literals
 
-import pytest
-import sys
 import socket
-
+import sys
 from collections import defaultdict
 from datetime import datetime, timedelta
 
+import pytest
 from case import Mock, call, patch
 from kombu import pidbox
 from kombu.utils.uuid import uuid
 
 from celery.five import Queue as FastQueue
+from celery.utils.collections import AttributeDict
 from celery.utils.timer2 import Timer
 from celery.worker import WorkController as _WC  # noqa
-from celery.worker import consumer
-from celery.worker import control
+from celery.worker import consumer, control
 from celery.worker import state as worker_state
+from celery.worker.pidbox import Pidbox, gPidbox
 from celery.worker.request import Request
 from celery.worker.state import revoked
-from celery.worker.pidbox import Pidbox, gPidbox
-from celery.utils.collections import AttributeDict
 
 hostname = socket.gethostname()
 

--- a/t/unit/worker/test_heartbeat.py
+++ b/t/unit/worker/test_heartbeat.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, unicode_literals
+
 from case import Mock
+
 from celery.worker.heartbeat import Heart
 
 

--- a/t/unit/worker/test_loops.py
+++ b/t/unit/worker/test_loops.py
@@ -2,15 +2,14 @@ from __future__ import absolute_import, unicode_literals
 
 import errno
 import socket
-import pytest
 
+import pytest
 from case import Mock
-from kombu.async import Hub, READ, WRITE, ERR
+from kombu.asynchronous import ERR, READ, WRITE, Hub
 
 from celery.bootsteps import CLOSE, RUN
-from celery.exceptions import (
-    InvalidTaskError, WorkerLostError, WorkerShutdown, WorkerTerminate,
-)
+from celery.exceptions import (InvalidTaskError, WorkerLostError,
+                               WorkerShutdown, WorkerTerminate)
 from celery.five import Empty, python_2_unicode_compatible
 from celery.platforms import EX_FAILURE
 from celery.worker import state

--- a/t/unit/worker/test_request.py
+++ b/t/unit/worker/test_request.py
@@ -3,43 +3,29 @@ from __future__ import absolute_import, unicode_literals
 
 import numbers
 import os
-import pytest
 import signal
 import socket
 import sys
-
 from datetime import datetime, timedelta
 
-from case import Mock, patch
+import pytest
 from billiard.einfo import ExceptionInfo
-from kombu.utils.encoding import default_encode, from_utf8, safe_str, safe_repr
+from case import Mock, patch
+from kombu.utils.encoding import (default_encode, from_utf8, safe_repr,
+                                  safe_str)
 from kombu.utils.uuid import uuid
 
 from celery import states
-from celery.app.trace import (
-    trace_task,
-    _trace_task_ret,
-    TraceInfo,
-    mro_lookup,
-    build_tracer,
-    setup_worker_optimizations,
-    reset_worker_optimizations,
-)
-from celery.exceptions import (
-    Ignore,
-    InvalidTaskError,
-    Reject,
-    Retry,
-    TaskRevokedError,
-    Terminated,
-    WorkerLostError,
-)
+from celery.app.trace import (TraceInfo, _trace_task_ret, build_tracer,
+                              mro_lookup, reset_worker_optimizations,
+                              setup_worker_optimizations, trace_task)
+from celery.exceptions import (Ignore, InvalidTaskError, Reject, Retry,
+                               TaskRevokedError, Terminated, WorkerLostError)
 from celery.five import monotonic
 from celery.signals import task_revoked
 from celery.worker import request as module
-from celery.worker.request import (
-    Request, create_request_cls, logger as req_logger,
-)
+from celery.worker.request import Request, create_request_cls
+from celery.worker.request import logger as req_logger
 from celery.worker.state import revoked
 
 

--- a/t/unit/worker/test_revoke.py
+++ b/t/unit/worker/test_revoke.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, unicode_literals
+
 from celery.worker import state
 
 

--- a/t/unit/worker/test_state.py
+++ b/t/unit/worker/test_state.py
@@ -1,12 +1,15 @@
 from __future__ import absolute_import, unicode_literals
+
 import pickle
-import pytest
 from time import time
+
+import pytest
 from case import Mock, patch
+
 from celery import uuid
 from celery.exceptions import WorkerShutdown, WorkerTerminate
-from celery.worker import state
 from celery.utils.collections import LimitedSet
+from celery.worker import state
 
 
 @pytest.fixture

--- a/t/unit/worker/test_strategy.py
+++ b/t/unit/worker/test_strategy.py
@@ -1,17 +1,16 @@
 from __future__ import absolute_import, unicode_literals
 
-import pytest
-
 from collections import defaultdict
 from contextlib import contextmanager
 
+import pytest
 from case import Mock, patch
 from kombu.utils.limits import TokenBucket
 
 from celery.exceptions import InvalidTaskError
+from celery.utils.time import rate
 from celery.worker import state
 from celery.worker.strategy import proto1_to_proto2
-from celery.utils.time import rate
 
 
 class test_proto1_to_proto2:

--- a/t/unit/worker/test_worker.py
+++ b/t/unit/worker/test_worker.py
@@ -1,15 +1,14 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 import os
-import pytest
 import socket
 import sys
-
 from collections import deque
 from datetime import datetime, timedelta
 from functools import partial
 from threading import Event
 
+import pytest
 from amqp import ChannelError
 from case import Mock, patch, skip
 from kombu import Connection
@@ -18,24 +17,23 @@ from kombu.transport.base import Message
 from kombu.transport.memory import Transport
 from kombu.utils.uuid import uuid
 
-from celery.bootsteps import RUN, CLOSE, TERMINATE, StartStopStep
+from celery.bootsteps import CLOSE, RUN, TERMINATE, StartStopStep
 from celery.concurrency.base import BasePool
-from celery.exceptions import (
-    WorkerShutdown, WorkerTerminate, TaskRevokedError,
-    InvalidTaskError, ImproperlyConfigured,
-)
-from celery.five import Empty, range, Queue as FastQueue
+from celery.exceptions import (ImproperlyConfigured, InvalidTaskError,
+                               TaskRevokedError, WorkerShutdown,
+                               WorkerTerminate)
+from celery.five import Empty
+from celery.five import Queue as FastQueue
+from celery.five import range
 from celery.platforms import EX_FAILURE
-from celery.worker import worker as worker_module
-from celery.worker import components
-from celery.worker import consumer
-from celery.worker import state
-from celery.worker.consumer import Consumer
-from celery.worker.pidbox import gPidbox
-from celery.worker.request import Request
 from celery.utils.nodenames import worker_direct
 from celery.utils.serialization import pickle
 from celery.utils.timer2 import Timer
+from celery.worker import components, consumer, state
+from celery.worker import worker as worker_module
+from celery.worker.consumer import Consumer
+from celery.worker.pidbox import gPidbox
+from celery.worker.request import Request
 
 
 def MockStep(step=None):
@@ -1049,7 +1047,7 @@ class test_WorkController(ConsumerCase):
         assert w.process_task is w._process_task
 
     def test_Pool_create(self):
-        from kombu.async.semaphore import LaxBoundedSemaphore
+        from kombu.asynchronous.semaphore import LaxBoundedSemaphore
         w = Mock()
         w._conninfo.connection_errors = w._conninfo.channel_errors = ()
         w.hub = Mock()


### PR DESCRIPTION
Pull in latest stable upstream. Some our fixes are still not there so we need to keep the fork for now.

Changes are prettification and import maintenance. That includes `kombu.async -> kombu.asynchronous` which kombu 4.2.0 needs and we need as well.
