### PR TITLE
Make redis backend greenlet-safe

### DIFF
--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -52,10 +52,11 @@ class ResultConsumer(async.BaseResultConsumer):
         self.subscribed_to = set()
         self.subscribe_lock = threading.Lock()
 
-    def start(self, **kwargs):
+    def start(self, initial_task_id, **kwargs):
         self._pubsub = self.backend.client.pubsub(
             ignore_subscribe_messages=True,
         )
+        self._consume_from(initial_task_id)
 
     def on_wait_for_pending(self, result, **kwargs):
         for meta in result._iter_meta():
@@ -73,7 +74,7 @@ class ResultConsumer(async.BaseResultConsumer):
 
     def consume_from(self, task_id):
         if self._pubsub is None:
-            return self.start()
+            return self.start(task_id)
         self._consume_from(task_id)
 
     def _consume_from(self, task_id):

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -79,16 +79,16 @@ class ResultConsumer(async.BaseResultConsumer):
 
     def _consume_from(self, task_id):
         key = self._get_key_for_task(task_id)
-        with self._subscribe_lock:
-            if key not in self.subscribed_to:
-                self.subscribed_to.add(key)
+        if key not in self.subscribed_to:
+            self.subscribed_to.add(key)
+            with self._subscribe_lock:
                 self._pubsub.subscribe(key)
 
     def cancel_for(self, task_id):
         if self._pubsub:
             key = self._get_key_for_task(task_id)
+            self.subscribed_to.discard(key)
             with self._subscribe_lock:
-                self.subscribed_to.discard(key)
                 self._pubsub.unsubscribe(key)
 
 


### PR DESCRIPTION
Partially addresses https://github.com/celery/celery/issues/4363 https://github.com/celery/celery/issues/4670

See my comment in https://github.com/celery/celery/pull/5145#issuecomment-488873389 for explanation.
This PR doesn't completely solve the problem, but at least it should solve it for gevent/eventlet.
